### PR TITLE
Allow latest Highcharts 6 with npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express-session": "^1.15.6",
     "glob": "^7.1.2",
     "hbs": "~4.0.1",
-    "highcharts": "^6.0.4",
+    "highcharts": "^6",
     "highcharts-map-collection": "github:highcharts/map-collection",
     "hostile": "^1.3.0",
     "http-proxy": "^1.16.2",


### PR DESCRIPTION
Installs always the latest release for proper comparison.