### PR TITLE
Extend getJS to change data URLs from rawgit.com to the relative local

### DIFF
--- a/lib/functions.js
+++ b/lib/functions.js
@@ -52,7 +52,7 @@ const getHTML = (req, codePath) => {
 		fs.readFileSync(
 			`${highchartsDir}samples/${path}/demo.html`
 		)
-		.toString();
+			.toString();
 
 	if (codePath) {
 
@@ -99,7 +99,7 @@ const getHTML = (req, codePath) => {
 	);
 
 	// Old IE
-	let safeCodePath = codePath || 'https://code.highcharts.com';
+	let safeCodePath = codePath || 'https://code.highcharts.com';
 	html += `
 	<!--[if lt IE 9]>
 	<script src='${safeCodePath}/modules/oldie.js'></script>
@@ -141,7 +141,7 @@ const getCSS = (path, codePath) => {
 	if (fs.existsSync(cssFile)) {
 		css =
 			fs.readFileSync(cssFile)
-			.toString();
+				.toString();
 
 		if (codePath) {
 			css = css.replace(
@@ -158,7 +158,6 @@ const getJS = (path) => {
 		`${highchartsDir}samples/${path}/demo.js`
 	);
 
-
 	// Validation
 	if (
 		js.indexOf('http://code.highcharts.com') !== -1 ||
@@ -169,6 +168,9 @@ const getJS = (path) => {
 		`;
 	}
 
+	if (js.indexOf('https://cdn.rawgit.com/highcharts/highcharts/')) {
+		js = new Buffer(js.toString().replace(new RegExp('([\\\'\\"])https\\:\\/\\/cdn\\.rawgit\\.com\\/highcharts\\/highcharts\\/[^\\/]+', 'g'), '/* $0 */ $1'));
+	}
 
 	return js;
 }
@@ -252,17 +254,17 @@ const getCodeFile = file => {
 
 	if (!fs.existsSync(file)) {
 		return {
-    		error: `console.error("File doesn't exist", "${file}");`
-    	};
-    }
-    if (!/\.(js|css)$/.test(file)) {
-    	return {
-    		error: `console.error("File type not allowed", "${file}");`
-    	}
-    }
-    return {
-    	success: file
-    };
+			error: `console.error("File doesn't exist", "${file}");`
+		};
+	}
+	if (!/\.(js|css)$/.test(file)) {
+		return {
+			error: `console.error("File type not allowed", "${file}");`
+		}
+	}
+	return {
+		success: file
+	};
 }
 
 module.exports = {


### PR DESCRIPTION
Utils server searches now inside JS files for
"https://cdn.rawgit.com/highcharts/highcharts/*/
and replaces it with 
/* ... */ "
so the demo data of the sources gets loaded at runtime.