### PR TITLE
Only catch errors in batch mode

### DIFF
--- a/public/javascripts/compare-iframe.js
+++ b/public/javascripts/compare-iframe.js
@@ -27,8 +27,10 @@ function compareHTML() {
 
 	// If running QUnit, use the built-in callback
 	if (QUnit) {
+		// Catch the error if batch mode, otherwise let it go.
+		QUnit.config.notrycatch = !controller.continueBatch;
+
 		if (navigator.userAgent.indexOf('PhantomJS') !== -1) {
-			QUnit.config.notrycatch = true;
 			QUnit.log(function( details ) {
 				if (!details.result ) {
 					var loc = details.module + ": " + details.name + ": ",


### PR DESCRIPTION
Will throw the error to the browser when running a single collection of tests. Makes it easier to debug when the error is accessible in the console.