### PR TITLE
Enhancement/npm support

### DIFF
--- a/app-api.js
+++ b/app-api.js
@@ -1,6 +1,5 @@
 // Modules sorted by names alphabetically
 const express = require('express');
-const http = require('http');
 const { join, resolve } = require('path');
 const { apiPort, highchartsDir } = require('./config.json');
 
@@ -11,7 +10,6 @@ const apiDir = join(resolve(highchartsDir), 'build/api');
  * Create express application
  */
 const app = express();
-app.set('port', apiPort);
 
 // Redirect / to /highcharts
 app.use('/', (req, res, next) => {
@@ -27,5 +25,4 @@ app.use('/', express.static(apiDir, { extensions: ['html'] }));
 /**
  * Create HTTP server.
  */
-const server = http.createServer(app);
-server.listen(apiPort);
+app.listen(apiPort);

--- a/app-api.js
+++ b/app-api.js
@@ -1,0 +1,31 @@
+// Modules sorted by names alphabetically
+const express = require('express');
+const http = require('http');
+const { join, resolve } = require('path');
+const { apiPort, highchartsDir } = require('./config.json');
+
+// Constants
+const apiDir = join(resolve(highchartsDir), 'build/api');
+
+/**
+ * Create express application
+ */
+const app = express();
+app.set('port', apiPort);
+
+// Redirect / to /highcharts
+app.use('/', (req, res, next) => {
+    if (req.url === '/') {
+        return res.redirect(302, '/highcharts')
+    }
+    next();
+});
+
+// Serve content of api directory
+app.use('/', express.static(apiDir, { extensions: ['html'] }));
+
+/**
+ * Create HTTP server.
+ */
+const server = http.createServer(app);
+server.listen(apiPort);

--- a/app.js
+++ b/app.js
@@ -37,11 +37,11 @@ app.use('/temp', express.static( // non-cached temporary json files
   path.join(__dirname, 'temp')
 ));
 app.use('/reference', express.static(
-  path.join(__dirname, 'node_modules/highcharts'),
+  path.dirname(require.resolve('highcharts/package.json')),
   { maxAge: '10m' }
 ));
 app.use('/mapdata', express.static(
-  path.join(__dirname, 'node_modules/@highcharts/map-collection'),
+  path.dirname(require.resolve('@highcharts/map-collection/package.json')),
   { maxAge: '10m' }
 ));
 app.use('/samples/graphics', express.static(

--- a/app.js
+++ b/app.js
@@ -45,7 +45,7 @@ app.use('/mapdata', express.static(
   { maxAge: '10m' }
 ));
 app.use('/samples/graphics', express.static(
-  path.join(__dirname, cfg.highchartsDir, 'samples/graphics')
+  path.join(cfg.highchartsDir, 'samples/graphics')
 ));
 
 app.use(session({

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../server.js');

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
 	"highchartsDir": ".",
 	"utilsPort": 3030,
 	"codePort": 3031,
+	"apiPort": 3032,
 	"emulateKarma": false
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-	"highchartsDir": "./../highcharts/",
+	"highchartsDir": ".",
 	"utilsPort": 3030,
 	"codePort": 3031,
 	"emulateKarma": false

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -3,12 +3,12 @@ const yaml = require('js-yaml');
 const marked = require('marked');
 const branchName = require('current-git-branch');
 const latestCommit = require('./latest-commit');
-const path = require('path');
+const { join, resolve } = require('path');
 const babel = require("@babel/core");
 const browserDetect = require('browser-detect');
 
-const highchartsDir = require('./../config.json').highchartsDir;
-const samplesDir = `${highchartsDir}samples/`;
+const highchartsDir = resolve(require('./../config.json').highchartsDir);
+const samplesDir = join(highchartsDir, 'samples');
 const jsdelivrSamplePath = /https:\/\/cdn\.jsdelivr\.net\/gh\/highcharts\/highcharts@[a-z0-9.]+\/samples\/data\//g;
 
 /**
@@ -16,7 +16,7 @@ const jsdelivrSamplePath = /https:\/\/cdn\.jsdelivr\.net\/gh\/highcharts\/highch
  */
 const getDetails = (path) => {
 	let details;
-	let detailsFile = samplesDir + path + '/demo.details';
+	let detailsFile = join(samplesDir, path, 'demo.details');
 	if (fs.existsSync(detailsFile)) {
 		details = fs.readFileSync(detailsFile, 'utf8');
 		if (details) {
@@ -31,11 +31,7 @@ const getDetails = (path) => {
 }
 
 const getKarmaHTML = () => {
-	let files = require(path.join(
-		'..',
-		highchartsDir,
-		'test/karma-files.json'
-	));
+	let files = require(join(highchartsDir, 'test/karma-files.json'));
 
 	files = files.map(file => `
 		<script src="/${file}"></script>
@@ -53,7 +49,7 @@ const getHTML = (req, codePath) => {
 
 	let theme = req.session.theme;
 	let samplePath = req.query.path;
-	let file = `${highchartsDir}samples/${samplePath}/demo.html`;
+	let file = join(highchartsDir, 'samples', samplePath, 'demo.html');
 	let html = fs.existsSync(file) ?
 		fs.readFileSync(file).toString() :
 		`<div class="error-message"><strong>${samplePath}/demo.html</strong> does not exist in the file system.</div>`;
@@ -156,7 +152,7 @@ const getLatestCommit = () => {
 }
 
 const getCSS = (path, codePath) => {
-	const cssFile = `${highchartsDir}samples/${path}/demo.css`;
+	const cssFile = join(highchartsDir, 'samples', path, 'demo.css');
 	let css = '';
 
 	if (fs.existsSync(cssFile)) {
@@ -182,7 +178,7 @@ const getCSS = (path, codePath) => {
 const getJS = (path, req) => {
 	try {
 		let js = fs.readFileSync(
-			`${highchartsDir}samples/${path}/demo.js`,
+			join(highchartsDir, 'samples', path, 'demo.js'),
 			'utf8'
 		);
 
@@ -255,18 +251,18 @@ const getResources = (path) => {
 }
 
 const getReadme = (path) => {
-	let file = `${highchartsDir}samples/${path}/readme.md`;
+	let file = join(highchartsDir, 'samples', path, 'readme.md');
 	if (fs.existsSync(file)) {
 		return marked(fs.readFileSync(file).toString());
 	}
 }
 
 const getTestNotes = (path) => {
-	let file = `${highchartsDir}samples/${path}/test-notes.md`;
+	let file = join(highchartsDir, 'samples', path, 'test-notes.md');
 	if (fs.existsSync(file)) {
 		return marked(fs.readFileSync(file).toString());
 	}
-	file = `${highchartsDir}samples/${path}/test-notes.html`;
+	file = join(highchartsDir, 'samples', path, 'test-notes.html');
 	if (fs.existsSync(file)) {
 		return fs.readFileSync(file).toString();
 	}
@@ -281,21 +277,10 @@ const getCodeFile = file => {
 
 	// Get the full file location
 	if (file.indexOf('/lib/') === 0) {
-		file = path.join(
-			__dirname,
-			'..',
-			highchartsDir,
-			file.replace('/lib/', '/vendor/')
-		);
+		file = join(highchartsDir, file.replace('/lib/', '/vendor/'));
 
 	} else {
-		file = path.join(
-			__dirname,
-			'..',
-			highchartsDir,
-			'code',
-			file
-		);
+		file = join(highchartsDir, 'code', file);
 
 		// Always load source
 		file = file

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "precommit": "lint-staged",
     "demodata": "node ./utils/demo-data"
   },
+  "bin": "./bin/cli.js",
   "dependencies": {
     "@babel/core": "^7.4.5",
     "@babel/preset-env": "^7.4.5",

--- a/routes/bisect/bisect.js
+++ b/routes/bisect/bisect.js
@@ -2,7 +2,8 @@
 
 const express = require('express');
 const router = express.Router();
-const highchartsDir = require('../../config.json').highchartsDir;
+const { resolve } = require('path');
+const highchartsDir = resolve(require('../../config.json').highchartsDir);
 const { spawn } =  require('child_process');
 
 const git = cmd => new Promise((resolve, reject) => {

--- a/routes/bisect/commits-post.js
+++ b/routes/bisect/commits-post.js
@@ -1,11 +1,8 @@
 const express = require('express');
-const path = require('path');
 const router = express.Router();
-const highchartsDir = require('../../config.json').highchartsDir;
-const git = require('simple-git/promise')(highchartsDir);
 
 
-router.post('/', function(req, res, next) {
+router.post('/', function(req, res) {
 	req.session.branch = req.body.branch;
 	req.session.after = req.body.after;
 	req.session.before = req.body.before;

--- a/routes/bisect/commits.js
+++ b/routes/bisect/commits.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
-const highchartsDir = require('../../config.json').highchartsDir;
+const { resolve } = require('path');
+const highchartsDir = resolve(require('../../config.json').highchartsDir);
 const git = require('simple-git/promise')(highchartsDir);
 
 

--- a/routes/bisect/main-post.js
+++ b/routes/bisect/main-post.js
@@ -1,10 +1,8 @@
 const express = require('express');
-const path = require('path');
 const router = express.Router();
-const highchartsDir = require('../../config.json').highchartsDir;
 
 
-router.post('/', function(req, res, next) {
+router.post('/', function(req, res) {
 	req.session.html = req.body.html;
 	req.session.css = req.body.css;
 	req.session.js = req.body.js;

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const fs = require('fs');
+const { join } = require('path');
 
 router.get('/', function(req, res) {
 	
-	let path = fs.readFileSync('./path.txt', 'utf-8');
+	let path = fs.readFileSync(join(__dirname, 'path.txt'), 'utf-8');
 
 	res.redirect(`/samples/view?path=${path}&mobile=true`);
 });

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -5,7 +5,7 @@ const { join } = require('path');
 
 router.get('/', function(req, res) {
 	
-	let path = fs.readFileSync(join(__dirname, 'path.txt'), 'utf-8');
+	let path = fs.readFileSync(join(__dirname, '../path.txt'), 'utf-8');
 
 	res.redirect(`/samples/view?path=${path}&mobile=true`);
 });

--- a/routes/samples/compare-iframe.js
+++ b/routes/samples/compare-iframe.js
@@ -7,6 +7,7 @@ const f = require('./../../lib/functions.js');
 const fs = require('fs');
 const router = express.Router();
 const cfg = require('../../config.json');
+const { join } = require('path');
 
 const getHTML = (req, codePath) => {
 	let html = f.getHTML(req, codePath);
@@ -61,7 +62,7 @@ router.get('/', function(req, res) {
 
 	// Add-hoc unit tests in visual samples. Bad practice, should be undone.
 	let unitTestsFile =
-		cfg.highchartsDir + 'samples/' + path + '/unit-tests.js';
+		join(cfg.highchartsDir, 'samples', path, 'unit-tests.js');
 	if (fs.existsSync(unitTestsFile)) {
 		tpl.scripts.push(
 			'/javascripts/vendor/qunit-2.0.1.js'
@@ -73,7 +74,7 @@ router.get('/', function(req, res) {
 	}
 
 	// Add test.js
-	let testFile = cfg.highchartsDir + 'samples/' + path + '/tests.js';
+	let testFile = join(cfg.highchartsDir, 'samples', path, 'tests.js');
 	if (fs.existsSync(testFile)) {
 		tpl.testFile = fs.readFileSync(testFile);
 	}

--- a/routes/samples/data.js
+++ b/routes/samples/data.js
@@ -2,16 +2,10 @@ const express = require('express');
 const router = express.Router();
 const fs = require('fs');
 const cfg = require('../../config.json');
-const path = require('path');
+const { join } = require('path');
 
 router.get(/[a-z\/\-\.]+\.(js|json|csv)$/, function(req, res) {
-	let file = path.join(
-		__dirname,
-		'../..',
-		cfg.highchartsDir,
-		'samples/data',
-		req.path
-	);
+	let file = join(cfg.highchartsDir, 'samples/data', req.path);
 	if (!fs.existsSync(file)) {
 		res.status(404).send(`File not found: ${file}`);
 		return;

--- a/routes/samples/list-samples.js
+++ b/routes/samples/list-samples.js
@@ -3,9 +3,10 @@ const express = require('express');
 const router = express.Router();
 const f = require('./../../lib/functions.js');
 const fs = require('fs');
+const { join } = require('path');
 
 const highchartsDir = require('./../../config.json').highchartsDir;
-const samplesDir = `${highchartsDir}samples/`;
+const samplesDir = join(highchartsDir, 'samples');
 
 
 const getSample = (path) => {
@@ -23,7 +24,7 @@ const getSample = (path) => {
 		'test-notes.html'
 
 	].forEach(extraFile => {
-		let filePath = `${samplesDir}/${path}/${extraFile}`;
+		let filePath = join(samplesDir, path, extraFile);
 		if (fs.existsSync(filePath)) {
 			sample.files[extraFile] = true;
 		}
@@ -37,21 +38,16 @@ const getSamples = () => {
 	[
 		'highcharts', 'stock', 'maps', 'gantt', 'unit-tests', 'issues', 'cloud'
 	].forEach(group => {
-		if (fs.existsSync(samplesDir + group) && fs.lstatSync(samplesDir + group).isDirectory()) {
-			fs.readdirSync(samplesDir + group).forEach(subgroup => {
-				if (fs.lstatSync(samplesDir + group + '/' + subgroup)
-					.isDirectory()
-				) {
-					fs.readdirSync(
-						samplesDir + group + '/' + subgroup
-					).forEach(sample => {
-						let path = `${group}/${subgroup}/${sample}`;
-						if (fs.lstatSync(
-								samplesDir + path
-							).isDirectory() &&
-							fs.existsSync(
-								samplesDir + path + '/demo.html'
-							)
+		const groupDir = join(samplesDir, group);
+		if (fs.existsSync(groupDir) && fs.lstatSync(groupDir).isDirectory()) {
+			fs.readdirSync(groupDir).forEach(subgroup => {
+				const subgroupDir = join(groupDir, subgroup);
+				if (fs.lstatSync(subgroupDir).isDirectory()) {
+					fs.readdirSync(subgroupDir).forEach(sample => {
+						let path = join(subgroupDir, sample);
+						if (
+							fs.lstatSync(path).isDirectory() &&
+							fs.existsSync(join(path, 'demo.html'))
 						) {
 							samples.push(getSample(path));
 						}

--- a/routes/samples/list-samples.js
+++ b/routes/samples/list-samples.js
@@ -3,9 +3,9 @@ const express = require('express');
 const router = express.Router();
 const f = require('./../../lib/functions.js');
 const fs = require('fs');
-const { join } = require('path');
+const { join, resolve } = require('path');
 
-const highchartsDir = require('./../../config.json').highchartsDir;
+const highchartsDir = resolve(require('./../../config.json').highchartsDir);
 const samplesDir = join(highchartsDir, 'samples');
 
 

--- a/routes/samples/list-samples.js
+++ b/routes/samples/list-samples.js
@@ -3,15 +3,21 @@ const express = require('express');
 const router = express.Router();
 const f = require('./../../lib/functions.js');
 const fs = require('fs');
-const { join, resolve } = require('path');
+const { join, relative, resolve, sep } = require('path');
 
 const highchartsDir = resolve(require('./../../config.json').highchartsDir);
 const samplesDir = join(highchartsDir, 'samples');
 
-
+/**
+ * Creates a serializable representation of a sample.
+ *
+ * @param {string} path Absolute file path to sample directory
+ * @returns {object} Return sample
+ */
 const getSample = (path) => {
 	let sample = {
-		path: path,
+		// path is a url relative to sample directory
+		path: relative(samplesDir, path).split(sep).join('/'),
 		details: f.getDetails(path),
 		files: {}
 	};
@@ -24,7 +30,7 @@ const getSample = (path) => {
 		'test-notes.html'
 
 	].forEach(extraFile => {
-		let filePath = join(samplesDir, path, extraFile);
+		let filePath = join(path, extraFile);
 		if (fs.existsSync(filePath)) {
 			sample.files[extraFile] = true;
 		}

--- a/routes/samples/view.js
+++ b/routes/samples/view.js
@@ -10,6 +10,7 @@ const router = express.Router();
 const f = require('./../../lib/functions.js');
 const fs = require('fs');
 const ip = require('ip');
+const { join } = require('path');
 
 router.get('/', function(req, res) {
 	let resources = f.getResources(req.query.path);
@@ -17,7 +18,7 @@ router.get('/', function(req, res) {
 	let codePath = req.query.rightcommit ?
 		'https://github.highcharts.com/' + req.query.rightcommit :
 		'/code';
-	fs.writeFile('./path.txt', req.query.path, 'utf-8', (err) => {
+	fs.writeFile(join(__dirname, 'path.txt'), req.query.path, 'utf-8', (err) => {
 		if (err) {
 			console.log(err);
 		}

--- a/routes/samples/view.js
+++ b/routes/samples/view.js
@@ -18,7 +18,7 @@ router.get('/', function(req, res) {
 	let codePath = req.query.rightcommit ?
 		'https://github.highcharts.com/' + req.query.rightcommit :
 		'/code';
-	fs.writeFile(join(__dirname, 'path.txt'), req.query.path, 'utf-8', (err) => {
+	fs.writeFile(join(__dirname, '../../path.txt'), req.query.path, 'utf-8', (err) => {
 		if (err) {
 			console.log(err);
 		}

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ const topDomain = argv.topdomain || 'local';
 let sslEnabled = false;
 let utilsDomainLine = '';
 let codeDomainLine = '';
+let apiDomainLine = '';
 
 const log = () => {
   const ipAddress = ip.address();
@@ -25,6 +26,9 @@ const log = () => {
   Code server available at:
     ${codeDomainLine}- http://localhost:${cfg.codePort}
     - http://${ipAddress}:${cfg.codePort}
+  API server available at:
+    ${apiDomainLine}- http://localhost:${cfg.apiPort}
+    - http://${ipAddress}:${cfg.apiPort}
 
   SSL enabled: ${sslEnabled}
 
@@ -64,6 +68,9 @@ require('./bin/www');
 // Start code.highcharts.local
 require('./app-code');
 
+// Start api.highcharts.local
+require('./app-api');
+
 // Require colors
 require('colors');
 
@@ -74,7 +81,8 @@ proxy.on('error', console.error);
 
 const redirects = {
   'utils.highcharts.*': `http://localhost:${cfg.utilsPort}`,
-  'code.highcharts.*': `http://localhost:${cfg.codePort}`
+  'code.highcharts.*': `http://localhost:${cfg.codePort}`,
+  'api.highcharts.*': `http://localhost:${cfg.apiPort}`
 }
 if (argv.proxy !== false) {
   const server = http.createServer((req, res) => {
@@ -126,12 +134,15 @@ if (argv.proxy !== false) {
     // Set up the hosts file
     const domains = [
       `utils.highcharts.${topDomain}`,
-      `code.highcharts.${topDomain}`
+      `code.highcharts.${topDomain}`,
+      `api.highcharts.${topDomain}`
     ];
     const protocol = sslEnabled ? 'https' : 'http';
     utilsDomainLine = `- ${protocol}://${domains[0]}
     `;
     codeDomainLine = `- ${protocol}://${domains[1]}
+    `;
+    apiDomainLine = `- ${protocol}://${domains[2]}
     `;
     
     domains.forEach(domain => {

--- a/utils/demo-data/world-mortality.js
+++ b/utils/demo-data/world-mortality.js
@@ -24,7 +24,7 @@ const FS = require('fs');
 const Path = require('path');
 
 const csvParser = new RegExp('(\\"[^\\"]*?\\"|[^\\,]*?)([\\r\\n]+|\\,)', 'g');
-const targetFilePath = Path.join('../..', Config['highchartsDir'], 'samples/data/world-mortality.json');
+const targetFilePath = Path.join(Config['highchartsDir'], 'samples/data/world-mortality.json');
 //const xlsUrl = 'http://www.who.int/entity/healthinfo/global_burden_disease/GHE2015_Deaths-2015-country.xls?ua=1';
 const xlsExportedCsvFile = '/Users/torstein/Downloads/GHE2015_Deaths-2015-country.csv';
 

--- a/views/index.html
+++ b/views/index.html
@@ -54,6 +54,10 @@
 					<i class="fa fa-mobile"></i><br/>
 					Draft
 				</a>
+				<a href="//api.highcharts.local">
+					<i class="fa fa-book"></i><br/>
+					API
+				</a>
 				<!--a href="issue-stats">
 					<i class="fa fa-bar-chart"></i><br/>
 					Issue statistics


### PR DESCRIPTION
# Description
Does a few changes to enable `highcharts-utils` to be installed as a dependency through `npm`:
- `config.highchartsDir` is now relative to current working directory.
- `path.txt` is now relative to the package directory.
- Use `require.resolve` to locate the 
- Added executable, to support `npx highcharts-utils` once installed

Also added support for serving `api.highcharts.local` on this server.

## Usage
Install from GitHub: `npm install -D highcharts/highcharts-utils`

Then run the package with: `npx highcharts-utils`