### PR TITLE
Add support for CLI arguments

### DIFF
--- a/app-api.js
+++ b/app-api.js
@@ -1,10 +1,6 @@
 // Modules sorted by names alphabetically
 const express = require('express');
-const { join, resolve } = require('path');
-const { apiPort, highchartsDir } = require('./config.json');
-
-// Constants
-const apiDir = join(resolve(highchartsDir), 'build/api');
+const { apiDir, apiPort, } = require('./lib/arguments.js');
 
 /**
  * Create express application

--- a/app-code.js
+++ b/app-code.js
@@ -5,7 +5,7 @@
 const http = require('http');
 const fs = require('fs');
 const f = require('./lib/functions');
-const cfg = require('./config.json');
+const { codePort } = require('./lib/arguments.js');
 
 http.createServer(function(req, res) {
 
@@ -20,4 +20,4 @@ http.createServer(function(req, res) {
 
 	res.end(fs.readFileSync(file.success));
     
-}).listen(cfg.codePort);
+}).listen(codePort);

--- a/app.js
+++ b/app.js
@@ -11,7 +11,7 @@ var bodyParser = require('body-parser');
 var lessMiddleware = require('less-middleware');
 var hbs = require('hbs');
 var session = require('express-session');
-var cfg = require('./config.json');
+var { highchartsDir } = require('./lib/arguments.js');
 
 var app = express();
 
@@ -45,7 +45,7 @@ app.use('/mapdata', express.static(
   { maxAge: '10m' }
 ));
 app.use('/samples/graphics', express.static(
-  path.join(cfg.highchartsDir, 'samples/graphics')
+  path.join(highchartsDir, 'samples/graphics')
 ));
 
 app.use(session({

--- a/bin/www
+++ b/bin/www
@@ -7,13 +7,13 @@
 var app = require('../app');
 var debug = require('debug')('highcharts-utils:server');
 var http = require('http');
-var cfg = require('../config.json');
+const { utilsPort } = require('../lib/arguments.js');
 
 /**
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || cfg.utilsPort);
+const port = normalizePort(process.env.PORT || utilsPort);
 app.set('port', port);
 
 /**

--- a/config.json
+++ b/config.json
@@ -3,5 +3,9 @@
 	"utilsPort": 3030,
 	"codePort": 3031,
 	"apiPort": 3032,
-	"emulateKarma": false
+	"emulateKarma": false,
+	"pemFile": "./certs/highcharts.local.key.pem",
+	"crtFile": "./certs/highcharts.local.crt",
+	"proxy": true,
+	"topdomain": "local"
 }

--- a/lib/arguments.js
+++ b/lib/arguments.js
@@ -1,0 +1,48 @@
+const { join, resolve } = require('path');
+const yargs = require('yargs');
+const defaults = require('../config.json');
+
+// Describe CLI arguments
+const help = {
+    apiPort: 'The port number for the API server',
+    codePort: 'The port number for the code server',
+    crtFile: 'Set the path to the crt certificate file. Provide for SSL. If a relative path is provided then it will be relative to the current working directory',
+    emulateKarma: 'Run the tests in a Karma-like environment',
+    highchartsDir: 'Set the path to the highcharts repository directory. If a relative path is provided then it will be relative to the current working directory',
+    pemFile: 'Set the path to the pem certificate file. Provide for SSL. If a relative path is provided then it will be relative to the current working directory',
+    proxy: 'Wether to set up proxies for the servers',
+    topdomain: 'The domain name for the proxies. E.g code.highcharts.<topdomain>',
+    utilsPort: 'The port number for the utils server'
+};
+
+// Create CLI options for yargs
+const options = Object.keys(help).reduce((options, option) => {
+    options[option] = {
+        default: defaults[option],
+        describe: help[option]
+    }
+    return options;
+}, {});
+const argv = yargs.options(options).argv;
+
+// Collect argument values from yargs
+const { codePort, apiPort, emulateKarma, proxy , topdomain, utilsPort } = argv;
+
+// Handle paths
+const highchartsDir = resolve(argv.highchartsDir);
+const pemFile = resolve(argv.pemFile);
+const crtFile = resolve(argv.crtFile);
+
+module.exports = {
+    apiDir: join(highchartsDir, 'build/api'),
+    apiPort,
+    codePort,
+    crtFile,
+    emulateKarma,
+    highchartsDir,
+    pemFile,
+    proxy,
+    samplesDir: join(highchartsDir, 'samples'),
+    topdomain: topdomain,
+    utilsPort
+};

--- a/lib/arguments.js
+++ b/lib/arguments.js
@@ -1,3 +1,4 @@
+const { existsSync, readFileSync } = require('fs');
 const { join, resolve } = require('path');
 const yargs = require('yargs');
 const defaults = require('../config.json');
@@ -15,6 +16,22 @@ const help = {
     utilsPort: 'The port number for the utils server'
 };
 
+const parseEnvFile = function (path) {
+    const environmentFile = existsSync(path) ? readFileSync(path, 'utf8') : '';
+    environmentFile.split('\n').forEach(line => {
+        line = line.trim();
+        if (
+            line.length && // Ignore empty lines
+            !line.startsWith('#') // Ignore comments
+        ) {
+            const [key, value] = line.split('=');
+            process.env[key] = value;
+        }
+    });
+}
+
+parseEnvFile(join(process.cwd(), '.env'));
+
 // Create CLI options for yargs
 const options = Object.keys(help).reduce((options, option) => {
     options[option] = {
@@ -23,7 +40,7 @@ const options = Object.keys(help).reduce((options, option) => {
     }
     return options;
 }, {});
-const argv = yargs.options(options).argv;
+const argv = yargs.options(options).env('utils').argv;
 
 // Collect argument values from yargs
 const { codePort, apiPort, emulateKarma, proxy , topdomain, utilsPort } = argv;

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -3,12 +3,11 @@ const yaml = require('js-yaml');
 const marked = require('marked');
 const branchName = require('current-git-branch');
 const latestCommit = require('./latest-commit');
-const { join, resolve } = require('path');
+const { join } = require('path');
 const babel = require("@babel/core");
 const browserDetect = require('browser-detect');
 
-const highchartsDir = resolve(require('./../config.json').highchartsDir);
-const samplesDir = join(highchartsDir, 'samples');
+const { highchartsDir, samplesDir } = require('./arguments.js');
 const jsdelivrSamplePath = /https:\/\/cdn\.jsdelivr\.net\/gh\/highcharts\/highcharts@[a-z0-9.]+\/samples\/data\//g;
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -21,6 +21,8 @@ If you don't want to block port 80 and don't need the virtual hosts, run
 Run `nodemon ./bin/www` and open `http://localhost:3030`.
 
 ## Usage
+CLI arguments are available for preview with `npx highcharts-utils --help`, or an equivalent command.
+
 See [highcharts/samples](https://github.com/highcharts/highcharts/tree/master/samples)
 for description of how the samples are set up and how to use the utils.
 

--- a/routes/bisect/bisect.js
+++ b/routes/bisect/bisect.js
@@ -2,8 +2,7 @@
 
 const express = require('express');
 const router = express.Router();
-const { resolve } = require('path');
-const highchartsDir = resolve(require('../../config.json').highchartsDir);
+const { highchartsDir } = require('../../lib/arguments.js');
 const { spawn } =  require('child_process');
 
 const git = cmd => new Promise((resolve, reject) => {

--- a/routes/bisect/commits.js
+++ b/routes/bisect/commits.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { resolve } = require('path');
-const highchartsDir = resolve(require('../../config.json').highchartsDir);
+const { highchartsDir } = require('../../lib/arguments.js');
 const git = require('simple-git/promise')(highchartsDir);
 
 

--- a/routes/samples/compare-iframe.js
+++ b/routes/samples/compare-iframe.js
@@ -6,7 +6,7 @@ const express = require('express');
 const f = require('./../../lib/functions.js');
 const fs = require('fs');
 const router = express.Router();
-const cfg = require('../../config.json');
+const { emulateKarma, samplesDir } = require('../../lib/arguments.js');
 const { join } = require('path');
 
 const getHTML = (req, codePath) => {
@@ -35,7 +35,7 @@ router.get('/', function(req, res) {
 	}
 
 	let tpl = {
-		html: cfg.emulateKarma ? 
+		html: emulateKarma ? 
 			f.getKarmaHTML() :
 			getHTML(req, codePath),
 		css: f.getCSS(path, codePath),
@@ -62,7 +62,7 @@ router.get('/', function(req, res) {
 
 	// Add-hoc unit tests in visual samples. Bad practice, should be undone.
 	let unitTestsFile =
-		join(cfg.highchartsDir, 'samples', path, 'unit-tests.js');
+		join(samplesDir, path, 'unit-tests.js');
 	if (fs.existsSync(unitTestsFile)) {
 		tpl.scripts.push(
 			'/javascripts/vendor/qunit-2.0.1.js'
@@ -74,7 +74,7 @@ router.get('/', function(req, res) {
 	}
 
 	// Add test.js
-	let testFile = join(cfg.highchartsDir, 'samples', path, 'tests.js');
+	let testFile = join(samplesDir, path, 'tests.js');
 	if (fs.existsSync(testFile)) {
 		tpl.testFile = fs.readFileSync(testFile);
 	}

--- a/routes/samples/data.js
+++ b/routes/samples/data.js
@@ -1,11 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const fs = require('fs');
-const cfg = require('../../config.json');
+const { samplesDir } = require('../../lib/arguments.js');
 const { join } = require('path');
 
 router.get(/[a-z\/\-\.]+\.(js|json|csv)$/, function(req, res) {
-	let file = join(cfg.highchartsDir, 'samples/data', req.path);
+	let file = join(samplesDir, 'data', req.path);
 	if (!fs.existsSync(file)) {
 		res.status(404).send(`File not found: ${file}`);
 		return;

--- a/routes/samples/list-samples.js
+++ b/routes/samples/list-samples.js
@@ -3,10 +3,8 @@ const express = require('express');
 const router = express.Router();
 const f = require('./../../lib/functions.js');
 const fs = require('fs');
-const { join, relative, resolve, sep } = require('path');
-
-const highchartsDir = resolve(require('./../../config.json').highchartsDir);
-const samplesDir = join(highchartsDir, 'samples');
+const { join, relative, sep } = require('path');
+const { samplesDir } = require('../../lib/arguments.js');
 
 /**
  * Creates a serializable representation of a sample.

--- a/routes/samples/view-source.js
+++ b/routes/samples/view-source.js
@@ -1,26 +1,22 @@
 const express = require('express');
 const fs = require('fs');
 const router = express.Router();
-const cfg = require('../../config.json');
-const f = require('./../../lib/functions.js');
 const path = require('path');
+const { samplesDir } = require('../../lib/arguments.js');
 
-router.get('/', function(req, res, next) {
+router.get('/', function(req, res) {
 	let html = path.join(
-		cfg.highchartsDir,
-		'samples',
+		samplesDir,
 		req.query.path,
 		'demo.html'
 	);
 	let css = path.join(
-		cfg.highchartsDir,
-		'samples',
+		samplesDir,
 		req.query.path,
 		'demo.css'
 	);
 	let js = path.join(
-		cfg.highchartsDir,
-		'samples',
+		samplesDir,
 		req.query.path,
 		'demo.js'
 	);

--- a/utils/demo-data/browser-versions.js
+++ b/utils/demo-data/browser-versions.js
@@ -9,11 +9,11 @@
  * ../../highcharts/samples/data/browser-versions.json
  */
 
- const Config = require('../../config.json');
 const FS = require('fs');
 const Path = require('path');
 const Request = require('request');
 const CompareVersions = require('compare-versions');
+const { samplesDir } = require('../../lib/arguments.js');
 
 const csvParser = new RegExp('(?:\\"([^\\"]+?)\\")\\,([\\d.]+)[\\r\\n]+', 'g');
 // Download URL taken from http://gs.statcounter.com/browser-version-market-share
@@ -139,7 +139,7 @@ module.exports = function () {
                 })
 
             FS.appendFile(
-                Path.join(Config['highchartsDir'], 'samples/data/browser-versions.json'),
+                Path.join(samplesDir, 'data/browser-versions.json'),
                 JSON.stringify(finalJson, undefined, '\t'),
                 { encoding: 'utf8', flag: 'w' },
                 (error) => {

--- a/utils/demo-data/large-dataset.js
+++ b/utils/demo-data/large-dataset.js
@@ -5,10 +5,10 @@
  * ../../highcharts/samples/data/large-dataset.json
  */
 
-const Config = require('../../config.json');
 const FS = require('fs');
 const Path = require('path');
 const Request = require('request');
+const { samplesDir } = require('../../lib/arguments.js');
 
 const url = 'http://vikjavev.no/ver/history.json.php?year=';
 
@@ -67,7 +67,7 @@ const loadVikTemperatureForYear = function (year) {
 const saveAsJs = function (json) {
     return new Promise((resolve, reject) => {
         FS.appendFile(
-            Path.join(Config['highchartsDir'], 'samples/data/large-dataset.js'),
+            Path.join(samplesDir, 'data/large-dataset.js'),
             (
                 '/* eslint no-unused-vars: 0 */\nvar temperatures = ' +
                 JSON.stringify(json, undefined, '    ') +
@@ -88,7 +88,7 @@ const saveAsJs = function (json) {
 const saveAsJson = function (json) {
     return new Promise((resolve, reject) => {
         FS.appendFile(
-            Path.join(Config['highchartsDir'], 'samples/data/large-dataset.json'),
+            Path.join(samplesDir, 'data/large-dataset.json'),
             JSON.stringify(json),
             { encoding: 'utf8', flag: 'w' },
             (error) => {

--- a/utils/demo-data/us-counties-unemployment.js
+++ b/utils/demo-data/us-counties-unemployment.js
@@ -4,10 +4,10 @@
  * ../../highcharts/samples/data/us-counties-unemployment.json
  */
 
-const Config = require('../../config.json');
 const FS = require('fs');
 const Path = require('path');
 const Request = require('request');
+const { samplesDir } = require('../../lib/arguments.js');
 
 const txtParser = new RegExp('(\\w+)\\s\\|\\s+(\\d+)\\s+\\|\\s+(\\d+)\\s+\\|\\s+([\\s\\w]+)\\,\\s(\\w{2,2})\\s+\\|\\s+(\\w\\w\\w)-(\\d\\d)\\s+\\|\\s+([\\d\\,]+)\\s+\\|\\s+([\\d\\,]+)\\s+\\|\\s+([\\d\\,]+)\\s+\\|\\s+([\\d\\.]+)', 'gm');
 const url = 'https://www.bls.gov/web/metro/laucntycur14.txt';
@@ -36,7 +36,7 @@ module.exports = function () {
             }
 
             FS.appendFile(
-                Path.join(Config['highchartsDir'], 'samples/data/us-counties-unemployment.json'),
+                Path.join(samplesDir, 'data/us-counties-unemployment.json'),
                 JSON.stringify(json, undefined, '\t'),
                 { encoding: 'utf8', flag: 'w' },
                 (error) => {

--- a/utils/demo-data/usdeur.js
+++ b/utils/demo-data/usdeur.js
@@ -5,11 +5,11 @@
  * ../../highcharts/samples/data/usdeur.json
  */
 
-const Config = require('../../config.json');
 const FS = require('fs');
 const Path = require('path');
 const Request = require('request');
 const Xml2Json = require('xml2json');
+const { samplesDir } = require('../../lib/arguments.js');
 
 const url = 'https://sdw-wsrest.ecb.europa.eu/service/data/EXR/D.USD.EUR.SP00.A?startPeriod=2007-01-01&endPeriod=2017-12-31&detail=dataonly';
 
@@ -77,7 +77,7 @@ const generateUsdEurJs = function (data) {
             js.push('];');
 
             FS.appendFile(
-                Path.join(Config['highchartsDir'], 'samples/data/usdeur.js'),
+                Path.join(samplesDir, 'data/usdeur.js'),
                 js.join('\n'),
                 { encoding: 'utf8', flag: 'w' },
                 (error) => {
@@ -115,7 +115,7 @@ const generateUsdEurJson = function (data) {
             });
 
             FS.appendFile(
-                Path.join(Config['highchartsDir'], 'samples/data/usdeur.json'),
+                Path.join(samplesDir, 'data/usdeur.json'),
                 JSON.stringify(json, undefined, '\t'),
                 { encoding: 'utf8', flag: 'w' },
                 (error) => {

--- a/utils/demo-data/world-mortality.js
+++ b/utils/demo-data/world-mortality.js
@@ -19,12 +19,12 @@
  * ../../highcharts/samples/data/world-mortality.json
  */
 
-const Config = require('../../config.json');
 const FS = require('fs');
 const Path = require('path');
+const { samplesDir } = require('../../lib/arguments.js');
 
 const csvParser = new RegExp('(\\"[^\\"]*?\\"|[^\\,]*?)([\\r\\n]+|\\,)', 'g');
-const targetFilePath = Path.join(Config['highchartsDir'], 'samples/data/world-mortality.json');
+const targetFilePath = Path.join(samplesDir, 'data/world-mortality.json');
 //const xlsUrl = 'http://www.who.int/entity/healthinfo/global_burden_disease/GHE2015_Deaths-2015-country.xls?ua=1';
 const xlsExportedCsvFile = '/Users/torstein/Downloads/GHE2015_Deaths-2015-country.csv';
 
@@ -131,7 +131,7 @@ module.exports = function () {
             }
 
             FS.appendFile(
-                Path.join(Config['highchartsDir'], 'samples/data/world-mortality.json'),
+                Path.join(samplesDir, 'data/world-mortality.json'),
                 JSON.stringify(finalJson, undefined, '\t'),
                 { encoding: 'utf8', flag: 'w' },
                 (error) => {

--- a/utils/demo-data/world-population.js
+++ b/utils/demo-data/world-population.js
@@ -6,11 +6,11 @@
  * ../../highcharts/samples/data/world-population.json
  */
 
-const Config = require('../../config.json');
 const FS = require('fs');
 const JSZip = require('jszip');
 const Path = require('path');
 const Request = require('request');
+const { samplesDir } = require('../../lib/arguments.js');
 
 const countries = require(Path.join(__dirname, 'countries.json'));
 const csvParser = new RegExp('(?:^|\\s+|\\,)(?:\\"([^\\"]*?)\\")+', 'gm');
@@ -132,7 +132,7 @@ const generateWorldPopulationDensityJson = function (fileInZip) {
         .then(json => {
             return new Promise((resolve, reject) => {
                 FS.appendFile(
-                    Path.join(Config['highchartsDir'], 'samples/data/world-population-density.json'),
+                    Path.join(samplesDir, 'data/world-population-density.json'),
                     JSON.stringify(json, undefined, '\t'),
                     { encoding: 'utf8', flag: 'w' },
                     (error) => {
@@ -153,7 +153,7 @@ const generateWorldPopulationHistoryCsv = function (zipFile) {
         .then(csv => {
             return new Promise((resolve, reject) => {
                 FS.appendFile(
-                    Path.join(Config['highchartsDir'], 'samples/data/world-population-history.csv'),
+                    Path.join(samplesDir, 'data/world-population-history.csv'),
                     csv.replace(new RegExp('[\\r\\n]+\\"Last Updated Date\\"[\\d\\,\\-\\"]+'), ''),
                     { encoding: 'utf8', flag: 'w' },
                     (error) => {
@@ -322,7 +322,7 @@ const generateWorldPopulationJson = function (fileInZip) {
         .then(json => {
             return new Promise((resolve, reject) => {
                 FS.appendFile(
-                    Path.join(Config['highchartsDir'], 'samples/data/world-population.json'),
+                    Path.join(samplesDir, 'data/world-population.json'),
                     JSON.stringify(json, undefined, '\t'),
                     { encoding: 'utf8', flag: 'w' },
                     (error) => {


### PR DESCRIPTION
Added support for CLI arguments `--apiPort`, `--codePort`, `--crtFile`, `--emulateKarma`, `--highchartsDir`, `--pemFile`, `--proxy/--no-proxy`, `--topdomain`, and `--utilsPort` 
- Defaults are set in `./config.json`
- Help instructions are set in `./lib/arguments.js`

Also added support for `.env` file in the current working directory. Similar to [dotenv](https://www.npmjs.com/package/dotenv)