### PR TITLE
Fixed error when running via bin/cli.js

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
 
+require = require("esm")(module)
 require('../server.js');


### PR DESCRIPTION
The CLI interface failed with `cannot use import statement outside a module`, for instance when running `npx highcharts-utils` from the Highcharts repo. (This was on Node 14.) Fixed by ~~replacing imports with require~~ loading the esm module. 