### PR TITLE
Added codesPort for localhost SSL without sudo.

### DIFF
--- a/app-code.js
+++ b/app-code.js
@@ -4,7 +4,7 @@
 
 // Modules sorted by names alphabetically
 const express = require('express');
-const { codePort } = require('./lib/arguments.js');
+const { crtFile, codePort, codesPort, pemFile } = require('./lib/arguments.js');
 const { getCodeFile } = require('./lib/functions');
 
 /**
@@ -34,3 +34,20 @@ app.use('/', (req, res) => {
  * Create HTTP server.
  */
 app.listen(codePort);
+
+/**
+ * Create HTTPS server.
+ */
+if (codesPort) {
+    const fs = require('fs');
+    const https = require('https');
+
+    const httpsOptions = {
+        key: fs.existsSync(pemFile) && fs.readFileSync(pemFile, 'utf-8'),
+        cert: fs.existsSync(crtFile) && fs.readFileSync(crtFile, 'utf-8')
+    };
+
+    if (httpsOptions.cert && httpsOptions.key) {
+        https.createServer(httpsOptions, app).listen(codesPort);
+    }
+}

--- a/app-code.js
+++ b/app-code.js
@@ -4,7 +4,7 @@
 
 // Modules sorted by names alphabetically
 const express = require('express');
-const { crtFile, codePort, codesPort, pemFile } = require('./lib/arguments.js');
+const { crtFile, codePort, codeSecurePort, pemFile } = require('./lib/arguments.js');
 const { getCodeFile } = require('./lib/functions');
 
 /**
@@ -38,7 +38,7 @@ app.listen(codePort);
 /**
  * Create HTTPS server.
  */
-if (codesPort) {
+if (codeSecurePort) {
     const fs = require('fs');
     const https = require('https');
 
@@ -48,6 +48,6 @@ if (codesPort) {
     };
 
     if (httpsOptions.cert && httpsOptions.key) {
-        https.createServer(httpsOptions, app).listen(codesPort);
+        https.createServer(httpsOptions, app).listen(codeSecurePort);
     }
 }

--- a/config.json
+++ b/config.json
@@ -2,6 +2,7 @@
 	"highchartsDir": "./../highcharts/",
 	"utilsPort": 3030,
 	"codePort": 3031,
+	"codeSecurePort": 3041,
 	"apiPort": 3032,
 	"emulateKarma": false,
 	"pemFile": "./certs/highcharts.local.key.pem",

--- a/lib/arguments.js
+++ b/lib/arguments.js
@@ -7,7 +7,7 @@ const defaults = require('../config.json');
 const help = {
     apiPort: 'The port number for the API server',
     codePort: 'The port number for the code server',
-    codesPort: 'The HTTPS port number for the code server',
+    codeSecurePort: 'The HTTPS port number for the code server',
     codeWatch: 'Whether to watch changes in the code and automatically reload the page',
     crtFile: 'Set the path to the crt certificate file. Provide for SSL. If a relative path is provided then it will be relative to the current working directory',
     emulateKarma: 'Run the tests in a Karma-like environment',
@@ -49,7 +49,7 @@ const argv = yargs.options(options).env('utils').argv;
 // Collect argument values from yargs
 const {
     codePort,
-    codesPort,
+    codeSecurePort,
     codeWatch,
     apiPort,
     emulateKarma,
@@ -69,7 +69,7 @@ module.exports = {
     apiDir: join(highchartsDir, 'build/api'),
     apiPort,
     codePort,
-    codesPort,
+    codeSecurePort,
     codeWatch,
     crtFile,
     emulateKarma,

--- a/lib/arguments.js
+++ b/lib/arguments.js
@@ -7,6 +7,7 @@ const defaults = require('../config.json');
 const help = {
     apiPort: 'The port number for the API server',
     codePort: 'The port number for the code server',
+    codesPort: 'The HTTPS port number for the code server',
     codeWatch: 'Whether to watch changes in the code and automatically reload the page',
     crtFile: 'Set the path to the crt certificate file. Provide for SSL. If a relative path is provided then it will be relative to the current working directory',
     emulateKarma: 'Run the tests in a Karma-like environment',
@@ -48,6 +49,7 @@ const argv = yargs.options(options).env('utils').argv;
 // Collect argument values from yargs
 const {
     codePort,
+    codesPort,
     codeWatch,
     apiPort,
     emulateKarma,
@@ -67,6 +69,7 @@ module.exports = {
     apiDir: join(highchartsDir, 'build/api'),
     apiPort,
     codePort,
+    codesPort,
     codeWatch,
     crtFile,
     emulateKarma,

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ require('colors');
 const {
   apiPort,
   codePort,
+  codesPort,
   crtFile,
   highchartsDir,
   localOnly,
@@ -36,12 +37,15 @@ const log = () => {
     - http://${ipAddress}:${utilsPort}
   Code server available at:
     ${codeDomainLine}- http://localhost:${codePort}
-    - http://${ipAddress}:${codePort}
+    - http://${ipAddress}:${codePort}${
+    codesPort ? `
+    ${codeDomainLine}- https://localhost:${codesPort}
+    - https://${ipAddress}:${codesPort}` : ''}
   API server available at:
     ${apiDomainLine}- http://localhost:${apiPort}
     - http://${ipAddress}:${apiPort}
 
-  SSL enabled: ${sslEnabled}
+  Proxy SSL enabled: ${sslEnabled}
 
   Parameters:
   Run --help to list parameters


### PR DESCRIPTION
It basically allows you to test locally when not an admin and have no host proxy, as JSFiddle forces HTTPS. Suggested codesPort is `3033` / `https://localhost:3033`, but it is not set by default.