### PR TITLE
Hide qunit box, then show it after tests.

### DIFF
--- a/public/javascripts/compare-iframe.js
+++ b/public/javascripts/compare-iframe.js
@@ -67,6 +67,10 @@ function compareHTML() {
 		};
 
 		QUnit.done(function (e) {
+			const qunitBox = document.getElementById('qunit');
+			if (qunitBox) {
+				qunitBox.style.display = 'block';
+			}
 			if (e.passed === e.total) {
 				window.parent.onIdentical();
 			} else {

--- a/public/stylesheets/style.less
+++ b/public/stylesheets/style.less
@@ -243,6 +243,9 @@ body.manual #comment-placeholder {
 body.unit #preview-row {
 	display: none;
 }
+#qunit {
+	display: none;
+}
 #qunit-tests li li.fail {
 	border-left: 10px solid #f15c80 !important;
 }


### PR DESCRIPTION
PR hides the `qunit` box when tests are running, then after tests are done, shows the div with results.

Checked the alternative: changing the order of elements (the qunit box and the container). It would require changes in dozens of files (easy to make a mistake and miss it) and doesn't look that good (or I simply like the current design 😅)

I don't have access to this repo, so PR made from a forked repo