### PR TITLE
Fixed wrong position of touch event pageX & pageY, and debug in touch.

### DIFF
--- a/public/javascripts/test-controller.js
+++ b/public/javascripts/test-controller.js
@@ -172,6 +172,22 @@ var TestController = /** @class */ (function () {
         Object.keys(extra).forEach(function (key) {
             evt[key] = extra[key];
         });
+
+        // Extend each touch with pageX and pageY after chart offset corrections
+        if (evt.touches) {
+            const twoFingers = evt.touches.length === 2;
+            evt.touches.forEach((touch, i) => {
+                if (twoFingers) {
+                    const sign = i ? 1 : -1;
+                    touch.pageX += 11 * sign;
+                    touch.pageY += 11 * sign;
+                } else {
+                    touch.pageX = extra.pageX;
+                    touch.pageY = extra.pageY;
+                }
+            });
+        }
+
         return evt;
     };
     /**
@@ -630,11 +646,11 @@ var TestController = /** @class */ (function () {
                 ])
             };
             if (i === 0) {
-                this.touchStart(chartX, chartY, undefined, extra, debug);
+                this.touchStart(movePoint1[0], movePoint1[1], undefined, extra, debug);
             }
-            this.touchMove(chartX, chartY, undefined, extra, debug);
+            this.touchMove(movePoint1[0], movePoint1[1], undefined, extra, debug);
             if (i === ie) {
-                this.touchEnd(chartX, chartY, undefined, extra, debug);
+                this.touchEnd(movePoint1[0], movePoint1[1], undefined, extra, debug);
             }
         }
     };


### PR DESCRIPTION
As in the description, fixed two problems:

- pageX and pageX props in `event.touches[]` array were always passed without chart's offset
- debug flag was always using `event.pageX` and `event.pageY` for rendering, which suggested the touch events were happening in correct position. It is still not perfect, as debug renders just one debug marker, while `pinch` could render two markers
