### PR TITLE
ESM migration progress for Node.js v22

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
         "es6": true
     },
     "parserOptions": {
-        "ecmaVersion": 2020
+        "ecmaVersion": 2022,
+        "sourceType": "module"
     },
     "rules": {
     	"no-undef": 2,

--- a/app-api.js
+++ b/app-api.js
@@ -1,6 +1,8 @@
 // Modules sorted by names alphabetically
-const express = require('express');
-const { apiDir, apiPort, } = require('./lib/arguments.js');
+import express from 'express';
+import args from './lib/arguments.js';
+
+const { apiDir, apiPort, } = args;
 
 /**
  * Create express application

--- a/app-code.js
+++ b/app-code.js
@@ -3,17 +3,20 @@
  */
 
 // Modules sorted by names alphabetically
-const express = require('express');
-const http = require('http');
+import express from 'express';
+import * as http from 'http';
+import args from './lib/arguments.js';
+import { getCodeFile } from './lib/functions.js';
+import { startWatchServer } from './lib/websocket.js';
+import * as fs from 'node:fs';
+import * as https from 'node:https';
+
 const {
 	crtFile,
 	codePort,
 	codeSecurePort,
 	pemFile
-} = require('./lib/arguments.js');
-const { getCodeFile } = require('./lib/functions');
-const { startWatchServer } = require('./lib/websocket.js');
-
+} = args;
 
 /**
  * Create express application
@@ -56,8 +59,6 @@ server.listen(codePort);
  * Create HTTPS server.
  */
 if (codeSecurePort) {
-    const fs = require('fs');
-    const https = require('https');
 
     const httpsOptions = {
         key: fs.existsSync(pemFile) && fs.readFileSync(pemFile, 'utf-8'),

--- a/app.js
+++ b/app.js
@@ -2,19 +2,23 @@
  * This is the main express app for utils.highcharts.local
  */
 
-var express = require('express');
-var path = require('path');
-var favicon = require('serve-favicon');
-var logger = require('morgan');
-var cookieParser = require('cookie-parser');
-var bodyParser = require('body-parser');
-var cors = require('cors');
-var lessMiddleware = require('less-middleware');
-var hbs = require('hbs');
-var session = require('express-session');
-var { highchartsDir } = require('./lib/arguments.js');
+import express from 'express';
+import * as path from 'node:path';
+import favicon from 'serve-favicon';
+import logger from 'morgan';
+import cookieParser from 'cookie-parser';
+import bodyParser from 'body-parser';
+import cors from 'cors';
+import lessMiddleware from 'less-middleware';
+import hbs from 'hbs';
+import session from 'express-session';
+import args from './lib/arguments.js';
+import * as dotenv from 'dotenv';
 
-require('dotenv').config();
+const __dirname = import.meta.dirname;
+const { highchartsDir } = args;
+
+dotenv.config();
 
 var app = express();
 
@@ -42,11 +46,11 @@ app.use('/temp', express.static( // non-cached temporary json files
   path.join(__dirname, 'temp')
 ));
 app.use('/reference', express.static(
-  path.dirname(require.resolve('highcharts/package.json')),
+  path.dirname(import.meta.resolve('highcharts/package.json')),
   { maxAge: '10m' }
 ));
 app.use('/mapdata', express.static(
-  path.dirname(require.resolve('@highcharts/map-collection/package.json')),
+  path.dirname(import.meta.resolve('@highcharts/map-collection/package.json')),
   /*
   path.dirname(require.resolve(path.join(
     __dirname,
@@ -67,46 +71,46 @@ app.use(session({
 
 
 // Routes
-app.use('/', require('./routes/index'));
-app.use('/code', require('./routes/code'));
-app.use('/draft', require('./routes/draft'));
-app.use('/pulls', require('./routes/pulls'));
+app.use('/', (await import('./routes/index.js')).default);
+app.use('/code', (await import('./routes/code.js')).default);
+// app.use('/draft', await import('./routes/draft'));
+// app.use('/pulls', await import('./routes/pulls'));
 
-// Bisect
-app.use('/bisect/', require('./routes/bisect/index'));
-app.use('/bisect/commits', require('./routes/bisect/commits'));
-app.use('/bisect/commits-post', require('./routes/bisect/commits-post'));
-app.use('/bisect/bisect', require('./routes/bisect/bisect'));
-app.use('/bisect/main', require('./routes/bisect/main'));
-app.use('/bisect/main-post', require('./routes/bisect/main-post'));
-app.use('/bisect/view', require('./routes/bisect/view'));
+// // Bisect
+// app.use('/bisect/', await import('./routes/bisect/index'));
+// app.use('/bisect/commits', await import('./routes/bisect/commits'));
+// app.use('/bisect/commits-post', await import('./routes/bisect/commits-post'));
+// app.use('/bisect/bisect', await import('./routes/bisect/bisect'));
+// app.use('/bisect/main', await import('./routes/bisect/main'));
+// app.use('/bisect/main-post', await import('./routes/bisect/main-post'));
+// app.use('/bisect/view', await import('./routes/bisect/view'));
 
 // Samples
-app.use('/samples/', require('./routes/samples/index'));
-app.use('/samples/data', require('./routes/samples/data'));
-app.use('/samples/contents', require('./routes/samples/contents'));
-app.use('/samples/mobile', require('./routes/samples/mobile'));
-app.use('/samples/nightly', require('./routes/samples/nightly'));
-app.use('/samples/list-samples', require('./routes/samples/list-samples'));
-app.use('/samples/jsfiddle-post', require('./routes/samples/share'));
-app.use('/samples/server-env', require('./routes/samples/server-env'));
-app.use('/samples/readme', require('./routes/samples/readme'));
-app.use('/samples/settings', require('./routes/samples/settings'));
-app.use('/samples/settings-post', require('./routes/samples/settings-post'));
-app.use('/samples/view', require('./routes/samples/view'));
-app.use('/samples/view-source', require('./routes/samples/view-source'));
-app.use(
-  '/samples/compare-comment',
-  require('./routes/samples/compare-comment')
-);
-app.use('/samples/compare-iframe', require('./routes/samples/compare-iframe'));
-app.use(
-  '/samples/compare-update-report',
-  require('./routes/samples/compare-update-report')
-);
-app.use('/samples/compare-report', require('./routes/samples/compare-report'));
-app.use('/samples/compare-reset', require('./routes/samples/compare-reset'));
-app.use('/samples/compare-view', require('./routes/samples/compare-view'));
+app.use('/samples/', (await import('./routes/samples/index.js')).default);
+// app.use('/samples/data', await import('./routes/samples/data'));
+// app.use('/samples/contents', await import('./routes/samples/contents'));
+// app.use('/samples/mobile', await import('./routes/samples/mobile'));
+// app.use('/samples/nightly', await import('./routes/samples/nightly'));
+// app.use('/samples/list-samples', await import('./routes/samples/list-samples'));
+// app.use('/samples/jsfiddle-post', await import('./routes/samples/share'));
+// app.use('/samples/server-env', await import('./routes/samples/server-env'));
+// app.use('/samples/readme', await import('./routes/samples/readme'));
+// app.use('/samples/settings', await import('./routes/samples/settings'));
+// app.use('/samples/settings-post', await import('./routes/samples/settings-post'));
+// app.use('/samples/view', await import('./routes/samples/view'));
+// app.use('/samples/view-source', await import('./routes/samples/view-source'));
+// app.use(
+//   '/samples/compare-comment',
+//   await import('./routes/samples/compare-comment')
+// );
+// app.use('/samples/compare-iframe', await import('./routes/samples/compare-iframe'));
+// app.use(
+//   '/samples/compare-update-report',
+//   await import('./routes/samples/compare-update-report')
+// );
+// app.use('/samples/compare-report', await import('./routes/samples/compare-report'));
+// app.use('/samples/compare-reset', await import('./routes/samples/compare-reset'));
+// app.use('/samples/compare-view', await import('./routes/samples/compare-view'));
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {
@@ -128,4 +132,4 @@ app.use(function(err, req, res, next) { // eslint-disable-line no-unused-vars
   });
 });
 
-module.exports = app;
+export default app;

--- a/app.js
+++ b/app.js
@@ -15,35 +15,35 @@ import session from 'express-session';
 import args from './lib/arguments.js';
 import * as dotenv from 'dotenv';
 
-const __dirname = import.meta.dirname;
+const dirname = import.meta.dirname;
 const { highchartsDir } = args;
 
 dotenv.config();
 
 var app = express();
 
-hbs.registerPartials(__dirname + '/views/partials');
+hbs.registerPartials(import.meta.dirname, '/views/partials');
 
 // view engine setup
-app.set('views', path.join(__dirname, 'views'));
+app.set('views', path.join(dirname, 'views'));
 app.set('view engine', 'hbs');
 
 app.use(cors());
 
-app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
+app.use(favicon(path.join(dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(lessMiddleware(path.join(__dirname, 'public')));
+app.use(lessMiddleware(path.join(dirname, 'public')));
 
 // Static
 app.use(express.static(
-  path.join(__dirname, 'public'),
+  path.join(dirname, 'public'),
   { maxAge: 60000 }
 ));
 app.use('/temp', express.static( // non-cached temporary json files
-  path.join(__dirname, 'temp')
+  path.join(dirname, 'temp')
 ));
 app.use('/reference', express.static(
   path.dirname(import.meta.resolve('highcharts/package.json')),
@@ -53,7 +53,7 @@ app.use('/mapdata', express.static(
   path.dirname(import.meta.resolve('@highcharts/map-collection/package.json')),
   /*
   path.dirname(require.resolve(path.join(
-    __dirname,
+    dirname,
     '../map-collection/Export/2.1.0'
   ))),
   // */
@@ -73,44 +73,44 @@ app.use(session({
 // Routes
 app.use('/', (await import('./routes/index.js')).default);
 app.use('/code', (await import('./routes/code.js')).default);
-// app.use('/draft', await import('./routes/draft'));
-// app.use('/pulls', await import('./routes/pulls'));
+app.use('/draft', (await import('./routes/draft.js')).default);
+app.use('/pulls', (await import('./routes/pulls.js')).default);
 
 // // Bisect
-// app.use('/bisect/', await import('./routes/bisect/index'));
-// app.use('/bisect/commits', await import('./routes/bisect/commits'));
-// app.use('/bisect/commits-post', await import('./routes/bisect/commits-post'));
-// app.use('/bisect/bisect', await import('./routes/bisect/bisect'));
-// app.use('/bisect/main', await import('./routes/bisect/main'));
-// app.use('/bisect/main-post', await import('./routes/bisect/main-post'));
-// app.use('/bisect/view', await import('./routes/bisect/view'));
+app.use('/bisect/', (await import('./routes/bisect/index.js')).default);
+app.use('/bisect/commits', (await import('./routes/bisect/commits.js')).default);
+app.use('/bisect/commits-post', (await import('./routes/bisect/commits-post.js')).default);
+app.use('/bisect/bisect', (await import('./routes/bisect/bisect.js')).default);
+app.use('/bisect/main', (await import('./routes/bisect/main.js')).default);
+app.use('/bisect/main-post', (await import('./routes/bisect/main-post.js')).default);
+app.use('/bisect/view', (await import('./routes/bisect/view.js')).default);
 
 // Samples
 app.use('/samples/', (await import('./routes/samples/index.js')).default);
-// app.use('/samples/data', await import('./routes/samples/data'));
-// app.use('/samples/contents', await import('./routes/samples/contents'));
-// app.use('/samples/mobile', await import('./routes/samples/mobile'));
-// app.use('/samples/nightly', await import('./routes/samples/nightly'));
-// app.use('/samples/list-samples', await import('./routes/samples/list-samples'));
-// app.use('/samples/jsfiddle-post', await import('./routes/samples/share'));
-// app.use('/samples/server-env', await import('./routes/samples/server-env'));
-// app.use('/samples/readme', await import('./routes/samples/readme'));
-// app.use('/samples/settings', await import('./routes/samples/settings'));
-// app.use('/samples/settings-post', await import('./routes/samples/settings-post'));
-// app.use('/samples/view', await import('./routes/samples/view'));
-// app.use('/samples/view-source', await import('./routes/samples/view-source'));
-// app.use(
-//   '/samples/compare-comment',
-//   await import('./routes/samples/compare-comment')
-// );
-// app.use('/samples/compare-iframe', await import('./routes/samples/compare-iframe'));
-// app.use(
-//   '/samples/compare-update-report',
-//   await import('./routes/samples/compare-update-report')
-// );
-// app.use('/samples/compare-report', await import('./routes/samples/compare-report'));
-// app.use('/samples/compare-reset', await import('./routes/samples/compare-reset'));
-// app.use('/samples/compare-view', await import('./routes/samples/compare-view'));
+app.use('/samples/data', (await import('./routes/samples/data.js')).default);
+app.use('/samples/contents', (await import('./routes/samples/contents.js')).default);
+app.use('/samples/mobile', (await import('./routes/samples/mobile.js')).default);
+app.use('/samples/nightly', (await import('./routes/samples/nightly.js')).default);
+app.use('/samples/list-samples', (await import('./routes/samples/list-samples.js')).default);
+app.use('/samples/jsfiddle-post', (await import('./routes/samples/share.js')).default);
+app.use('/samples/server-env', (await import('./routes/samples/server-env.js')).default);
+app.use('/samples/readme', (await import('./routes/samples/readme.js')).default);
+app.use('/samples/settings', (await import('./routes/samples/settings.js')).default);
+app.use('/samples/settings-post', (await import('./routes/samples/settings-post.js')).default);
+app.use('/samples/view', (await import('./routes/samples/view.js')).default);
+app.use('/samples/view-source', (await import('./routes/samples/view-source.js')).default);
+app.use(
+  '/samples/compare-comment',
+  (await import('./routes/samples/compare-comment.js')).default
+);
+app.use('/samples/compare-iframe', (await import('./routes/samples/compare-iframe.js')).default);
+app.use(
+  '/samples/compare-update-report',
+  (await import('./routes/samples/compare-update-report.js')).default
+);
+app.use('/samples/compare-report', (await import('./routes/samples/compare-report.js')).default);
+app.use('/samples/compare-reset', (await import('./routes/samples/compare-reset.js')).default);
+app.use('/samples/compare-view', (await import('./routes/samples/compare-view.js')).default);
 
 // catch 404 and forward to error handler
 app.use(function(req, res, next) {

--- a/bin/www
+++ b/bin/www
@@ -4,12 +4,15 @@
  * Module dependencies.
  */
 
-var app = require('../app');
-var debug = require('debug')('highcharts-utils:server');
-const fs = require('fs');
-var http = require('http');
-const { utilsPort, highchartsDir } = require('../lib/arguments.js');
-const { startWatchServer } = require('../lib/websocket');
+
+import app from '../app.js';
+import debugFactory from 'debug';
+import * as http from 'node:http';
+import args from '../lib/arguments.js';
+import { startWatchServer } from '../lib/websocket.js';
+
+const debug = debugFactory('highcharts-utils:server');
+const { utilsPort, highchartsDir } = args;
 
 /**
  * Get port from environment and store in Express.

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-	"highchartsDir": "./../highcharts/",
+	"highchartsDir": "../highcharts/",
 	"utilsPort": 3030,
 	"codePort": 3031,
 	"codeSecurePort": 3041,
@@ -10,7 +10,7 @@
 	"localOnly": false,
 	"pemFile": "./certs/highcharts.local.key.pem",
 	"crtFile": "./certs/highcharts.local.crt",
-	"proxy": true,
+	"proxy": false,
 	"topdomain": "local",
 	"useMinifiedCode": false,
 	"useESModules": false

--- a/lib/arguments.js
+++ b/lib/arguments.js
@@ -1,15 +1,15 @@
-const { existsSync, readFileSync, writeFileSync } = require('fs');
-const { join, resolve } = require('path');
-const yargs = require('yargs');
-const defaults = require('../config.json');
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import yargs from 'yargs';
+import defaults from '../config.json' with { type: "json" };
 
-const configPath = join(__dirname, '../temp/config-user.json');
+const configPath = join(import.meta.dirname, '../temp/config-user.json');
 if (!existsSync(configPath)) {
     writeFileSync(configPath, JSON.stringify({}));
 }
 
-const user = require('../temp/config-user.json') || {};
-const help = require('./settings-help');
+import user from '../temp/config-user.json' with { type: "json" };
+import help from './settings-help.js';
 
 const parseEnvFile = function (path) {
     const environmentFile = existsSync(path) ? readFileSync(path, 'utf8') : '';
@@ -35,7 +35,8 @@ const options = Object.keys(help).reduce((options, option) => {
     }
     return options;
 }, {});
-const argv = yargs.options(options).env('utils').argv;
+console.log(Object.keys(yargs));
+const argv = yargs().options(options).env('utils').argv;
 
 // Collect argument values from yargs
 const {
@@ -61,25 +62,10 @@ const crtFile = resolve(argv.crtFile);
 // Get up-to-date settings that may have been updated in runtime by
 // config-user.json, from the settings page
 const getSettings = () => {
-
-    const defaultJSON = readFileSync(
-        join(__dirname, '../config.json'),
-        'utf-8'
-    );
-    const dflt = JSON.parse(defaultJSON);
-    const userJSON = readFileSync(
-        join(__dirname, '../temp/config-user.json'),
-        'utf-8'
-    );
-    const user = userJSON ? JSON.parse(userJSON) : {};
-    return Object.keys(dflt)
-        .reduce(
-            (settings, key) => {
-                settings[key] = user[key] ?? dflt[key];
-                return settings;
-            },
-            {}
-        );
+    return {
+        ...defaults,
+        ...(userJSON ? JSON.parse(userJSON) : {})
+    }
 }
 
 const exp = {
@@ -102,7 +88,7 @@ const exp = {
     utilsPort
 };
 
-module.exports = {
+export default {
     getSettings,
     ...exp
 };

--- a/lib/compile-on-demand.js
+++ b/lib/compile-on-demand.js
@@ -1,8 +1,10 @@
-const esbuild = require('esbuild');
-const { highchartsDir } = require('./arguments.js');
-const { join } = require('path');
-const replacePlugin = require('esbuild-plugin-replace-regex');
-const semver = require('semver');
+import esbuild from 'esbuild';
+import args from './arguments.js';
+import { join } from 'node:path';
+import replacePlugin from 'esbuild-plugin-replace-regex';
+import semver from 'semver';
+
+const { highchartsDir } = args;
 
 // Esbuild (0.19.5) crashes on defaulting function arguments to
 // this.someThing
@@ -141,7 +143,7 @@ const replace = (js, umdConfig) => {
 }
 
 
-const compile = async (filename) => {
+export const compile = async (filename) => {
 
     const isPrimaryFile = [
         '/dashboards/datagrid.src.js',
@@ -261,6 +263,6 @@ if (typeof module === 'object' && module.exports) {
 }
 
 
-module.exports = {
+export default {
 	compile
 };

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -65,7 +65,10 @@ export const getDetails = (path) => {
 }
 
 export const getKarmaHTML = async () => {
-    let files = await import(join(highchartsDir, 'test/karma-files.json'), { with: { type: "json" } });
+    let files = await import(
+        join(highchartsDir, 'test/karma-files.json'),
+        { with: { type: "json" } }
+    );
 
     files = files.map(file => `
         <script src="/${file}"></script>
@@ -661,8 +664,8 @@ export async function getConfig() {
     ];
     const { join } = await import('path');
 
-    const json = await fs.promises.readFile(
-        join(__dirname, '../', 'temp', 'config-user.json'),
+    const json = await fsp.readFile(
+        join(import.meta.dirname, '..', 'temp', 'config-user.json'),
         'utf-8'
     );
     const user = json ? JSON.parse(json) : {};

--- a/lib/functions.js
+++ b/lib/functions.js
@@ -1,16 +1,16 @@
-const fs = require('fs');
-const yaml = require('js-yaml');
-const marked = require('marked');
-const branchName = require('current-git-branch');
-const latestCommit = require('./latest-commit');
-const { join } = require('path');
-const { jsToESM, htmlToESM } = require('../public/javascripts/tools/jsfiddle-to-esm');
-const babel = require("@babel/core");
-const browserDetect = require('browser-detect');
-const { JSDOM } = require('jsdom');
-const https = require('https');
-const moment = require('moment'); // Using dateFormat
-const { compile } = require('./compile-on-demand');
+import * as fs from 'node:fs';
+import yaml from 'js-yaml';
+import * as marked from 'marked';
+import branchName from 'current-git-branch';
+import latestCommit from './latest-commit.js';
+import { join } from 'node:path';
+import { jsToESM, htmlToESM } from '../public/javascripts/tools/jsfiddle-to-esm.js';
+import babel from "@babel/core";
+import browserDetect from 'browser-detect';
+import { JSDOM } from 'jsdom';
+import https from 'node:https';
+import moment from 'moment'; // Using dateFormat
+import { compile } from './compile-on-demand.js';
 
 const fsp = fs.promises;
 
@@ -18,11 +18,11 @@ const {
     getSettings,
     highchartsDir,
     samplesDir
-} = require('./arguments.js');
+} = await import('./arguments.js');
 const jsdelivrSamplePath = /https:\/\/cdn\.jsdelivr\.net\/gh\/highcharts\/highcharts@[a-z0-9.]+\/samples\/data\//g;
 const VREVS_ENDPOINT = 'https://vrevs.highsoft.com/api/assets/';
 
-const getJSON = async (url) => new Promise ((resolve, reject) => {
+export const getJSON = async (url) => new Promise ((resolve, reject) => {
     https.get(url, (resp) => {
         let data = '';
 
@@ -48,7 +48,7 @@ const getJSON = async (url) => new Promise ((resolve, reject) => {
 /**
  * Get demo.details in form of an object
  */
-const getDetails = (path) => {
+export const getDetails = (path) => {
     let details;
     let detailsFile = join(samplesDir, path, 'demo.details');
     if (fs.existsSync(detailsFile)) {
@@ -64,8 +64,8 @@ const getDetails = (path) => {
     return details || {};
 }
 
-const getKarmaHTML = () => {
-    let files = require(join(highchartsDir, 'test/karma-files.json'));
+export const getKarmaHTML = async () => {
+    let files = await import(join(highchartsDir, 'test/karma-files.json'), { with: { type: "json" } });
 
     files = files.map(file => `
         <script src="/${file}"></script>
@@ -86,7 +86,7 @@ const getKarmaHTML = () => {
  * @param {string} path The file path
  * @returns {boolean} True if it should be replaced, otherwise false
  */
-const shouldUseCompiled = path => (
+export const shouldUseCompiled = path => (
     path.includes('.src.js')
 );
 
@@ -96,7 +96,7 @@ const shouldUseCompiled = path => (
  * @param {string} html The html content
  * @return {Array<string>} Returns list of the src values
  */
-const getScriptTagSrcValues = html => {
+export const getScriptTagSrcValues = html => {
     const startValue = 'src="';
     const endValue = '"';
     return html
@@ -117,7 +117,7 @@ const getScriptTagSrcValues = html => {
  * @param {string} codePath New code path to replace URL base with
  * @return {string} The new string with replacements done
  */
-const replaceURLs = (str, codePath) => {
+export const replaceURLs = (str, codePath) => {
 
     let ret = str.replace(
         /https:\/\/code\.highcharts\.com\/mapdata/g,
@@ -152,7 +152,7 @@ const replaceURLs = (str, codePath) => {
 };
 
 
-const getHTML = (req, codePath) => {
+export const getHTML = (req, codePath) => {
 
     const { theme } = req.session,
         { useESModules } = getSettings();
@@ -262,17 +262,17 @@ const getHTML = (req, codePath) => {
     return html;
 }
 
-const getBranch = () => {
+export const getBranch = () => {
     return branchName({ altPath: highchartsDir });
 }
 
-const getLatestCommit = () => {
+export const getLatestCommit = () => {
     const commit = latestCommit(highchartsDir);
 
     return commit.commit.substr(0, 10);
 }
 
-const getThemes = async (req) => {
+export const getThemes = async (req) => {
     const files = await fsp.readdir(`${highchartsDir}/ts/Extensions/Themes`);
 
     const themes = files.reduce((themes, file) => {
@@ -294,9 +294,9 @@ const getThemes = async (req) => {
     return themes;
 }
 
-const getLatestTag = () => latestCommit(highchartsDir, true);
+export const getLatestTag = () => latestCommit(highchartsDir, true);
 
-const getCSS = (path, codePath) => {
+export const getCSS = (path, codePath) => {
     const cssFile = join(highchartsDir, 'samples', path, 'demo.css');
     let css = '';
 
@@ -312,7 +312,7 @@ const getCSS = (path, codePath) => {
     return css;
 }
 
-const getJS = (path, req, codePath, es6Context) => {
+export const getJS = (path, req, codePath, es6Context) => {
     try {
 
         const { useESModules } = getSettings();
@@ -393,7 +393,7 @@ const getJS = (path, req, codePath, es6Context) => {
     }
 }
 
-const getResources = (path) => {
+export const getResources = (path) => {
     let details = getDetails(path);
     let resources = {
         scripts: [],
@@ -425,14 +425,14 @@ const getResources = (path) => {
     return resources;
 }
 
-const getReadme = (path) => {
+export const getReadme = (path) => {
     let file = join(highchartsDir, 'samples', path, 'readme.md');
     if (fs.existsSync(file)) {
         return marked.parse(fs.readFileSync(file).toString());
     }
 }
 
-const getTestNotes = (path) => {
+export const getTestNotes = (path) => {
     let file = join(highchartsDir, 'samples', path, 'test-notes.md');
     if (fs.existsSync(file)) {
         return marked.parse(fs.readFileSync(file).toString());
@@ -446,7 +446,7 @@ const getTestNotes = (path) => {
 /**
  * Get the code file path or return errors on failure
  */
-const getCodeFile = async (file, req) => {
+export const getCodeFile = async (file, req) => {
 
     const { codeWatch, compileOnDemand, useMinifiedCode } = getSettings(req);
 
@@ -598,7 +598,7 @@ const getCodeFile = async (file, req) => {
 }
 
 
-const getNightlyResult = async (date) => {
+export const getNightlyResult = async (date) => {
     const daysToTry = 5;
 
     for (let day = 0; day < daysToTry; day++) { // Try some days back
@@ -649,9 +649,9 @@ const getNightlyResult = async (date) => {
     return `Failed to get results ${daysToTry} days back`;
 }
 
-async function getConfig() {
-    const config = require('../config.json');
-    const help = require('./settings-help');
+export async function getConfig() {
+    const config = await import('../config.json');
+    const help = await import('./settings-help');
     const runtimeList = [
         'codeWatch',
         'compileOnDemand',
@@ -659,7 +659,7 @@ async function getConfig() {
         'useESModules',
         'useMinifiedCode'
     ];
-    const { join } = require('path');
+    const { join } = await import('path');
 
     const json = await fs.promises.readFile(
         join(__dirname, '../', 'temp', 'config-user.json'),
@@ -690,7 +690,7 @@ async function getConfig() {
     return options;
 }
 
-module.exports = {
+export default {
     getBranch,
     getDetails,
     getHTML,

--- a/lib/latest-commit.js
+++ b/lib/latest-commit.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const execSync = require('child_process').execSync;
+import { execSync } from 'node:child_process';
 
 const parseAuthor = /^Author:\s+([^<]*)/m;
 const parseCommit = /^commit\s+([0-9a-f]{40,})/m;
 const parseDate = /^Date:\s+(.*)$/m;
 const parseEmail = /^Author:\s+[^<]*<([^>]+)>/m;
 
-module.exports = function (cwd, latestTag) {
+export default function (cwd, latestTag) {
 
     const cmd = latestTag ?
         'git log --tags -n 1' :

--- a/lib/settings-help.js
+++ b/lib/settings-help.js
@@ -1,5 +1,5 @@
 // Describe CLI arguments
-module.exports = {
+export default {
     apiPort: 'The port number for the API server.',
     codePort: 'The port number for the code server.',
     codeSecurePort: 'The HTTPS port number for the code server.',

--- a/lib/websocket.js
+++ b/lib/websocket.js
@@ -1,8 +1,10 @@
-const fs = require('fs'),
-    { highchartsDir } = require('./arguments.js');
-    WebSocket = require('ws');
+import * as fs from 'fs';
+import args from './arguments.js';
+import WebSocket from 'ws';
 
-function startWatchServer(server) {
+const { highchartsDir } = args;
+
+export function startWatchServer(server) {
     console.log('@startWatchServer')
     const wss = new WebSocket.Server({ server });
     wss.on('connection', (ws) => {
@@ -45,6 +47,6 @@ function startWatchServer(server) {
     });
 };
 
-module.exports = {
+export default {
     startWatchServer
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2628,11 +2628,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3630,16 +3631,17 @@
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "node_modules/express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -3709,33 +3711,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
-    "node_modules/express/node_modules/body-parser": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.11.0",
-        "raw-body": "2.5.1",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3744,6 +3724,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -3751,21 +3732,8 @@
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/express/node_modules/raw-body": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3802,9 +3770,10 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -3876,15 +3845,16 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -4426,9 +4396,10 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
+      "license": "MIT"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4511,6 +4482,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -6417,6 +6389,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -6834,9 +6807,10 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8673,11 +8647,11 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-detect": {
@@ -9397,16 +9371,16 @@
       }
     },
     "express": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
-      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
+      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.1",
+        "body-parser": "1.20.2",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.5.0",
+        "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -9434,29 +9408,10 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "body-parser": {
-          "version": "1.20.1",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
-          "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
-          "requires": {
-            "bytes": "3.1.2",
-            "content-type": "~1.0.4",
-            "debug": "2.6.9",
-            "depd": "2.0.0",
-            "destroy": "1.2.0",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "on-finished": "2.4.1",
-            "qs": "6.11.0",
-            "raw-body": "2.5.1",
-            "type-is": "~1.6.18",
-            "unpipe": "1.0.0"
-          }
-        },
         "cookie": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-          "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+          "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="
         },
         "debug": {
           "version": "2.6.9",
@@ -9470,17 +9425,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-        },
-        "raw-body": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
-          "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
-          "requires": {
-            "bytes": "3.1.2",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "unpipe": "1.0.0"
-          }
         }
       }
     },
@@ -9551,9 +9495,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -9612,9 +9556,9 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "foreachasync": {
       "version": "3.0.0",
@@ -9981,9 +9925,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ip": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-      "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
+      "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -11732,9 +11676,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "requires": {}
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "precommit": "lint-staged",
     "demodata": "node ./utils/demo-data"
   },
+  "type": "module",
   "bin": "./bin/cli.js",
   "dependencies": {
     "@babel/core": "^7.13.10",

--- a/routes/bisect/bisect.js
+++ b/routes/bisect/bisect.js
@@ -1,10 +1,12 @@
 /* eslint-env node,es6 */
 
-const express = require('express');
+import express from 'express';
+import semver from 'semver';
+import args from '../../lib/arguments.js';
+import { spawn } from 'node:child_process';
+
 const router = express.Router();
-const semver = require('semver');
-const { highchartsDir } = require('../../lib/arguments.js');
-const { spawn } =  require('child_process');
+const { highchartsDir } = args;
 
 const git = cmd => new Promise((resolve, reject) => {
 	const options = {
@@ -199,4 +201,4 @@ router.post('/', function(req, res) {
 	res.redirect('/bisect/bisect');
 });
 
-module.exports = router;
+export default router;

--- a/routes/bisect/commits-post.js
+++ b/routes/bisect/commits-post.js
@@ -1,6 +1,6 @@
-const express = require('express');
-const router = express.Router();
+import express from 'express';
 
+const router = express.Router();
 
 router.post('/', function(req, res) {
 	req.session.branch = req.body.branch;
@@ -10,4 +10,4 @@ router.post('/', function(req, res) {
 	res.redirect('/bisect/commits');
 });
 
-module.exports = router;
+export default router;

--- a/routes/bisect/commits.js
+++ b/routes/bisect/commits.js
@@ -1,8 +1,10 @@
-const express = require('express');
-const router = express.Router();
-const { highchartsDir } = require('../../lib/arguments.js');
-const git = require('simple-git/promise')(highchartsDir);
+import express from 'express';
+import args from '../../lib/arguments.js';
+import * as simplegit from 'simple-git';
 
+const router = express.Router();
+const { highchartsDir } = args;
+const git = simplegit.gitP(highchartsDir);
 
 router.get('/', function(req, res) {
 
@@ -87,4 +89,4 @@ router.get('/', function(req, res) {
         .catch((e) => res.status(500).send(e.toString()));
 });
 
-module.exports = router;
+export default router;

--- a/routes/bisect/index.js
+++ b/routes/bisect/index.js
@@ -1,9 +1,10 @@
-const express = require('express');
-const path = require('path');
+import express from 'express';
+import * as path from 'node:path';
+
 const router = express.Router();
 
-router.get('/', function(req, res, next) {
-  	res.sendFile(path.join(__dirname + '/../../views/bisect/index.html'));
+router.get('/', function(req, res) {
+  	res.sendFile(path.join(import.meta.dirname, '/../../views/bisect/index.html'));
 });
 
-module.exports = router;
+export default router;

--- a/routes/bisect/main-post.js
+++ b/routes/bisect/main-post.js
@@ -1,6 +1,6 @@
-const express = require('express');
-const router = express.Router();
+import express from 'express';
 
+const router = express.Router();
 
 router.post('/', function(req, res) {
 	req.session.html = req.body.html;
@@ -9,4 +9,4 @@ router.post('/', function(req, res) {
 	res.redirect('/bisect/main');
 });
 
-module.exports = router;
+export default router;

--- a/routes/bisect/main.js
+++ b/routes/bisect/main.js
@@ -1,8 +1,8 @@
-const express = require('express');
-const path = require('path');
+import express from 'express';
+
 const router = express.Router();
 
-router.get('/', function(req, res, next) {
+router.get('/', function(req, res) {
   	res.render('bisect/main', {
   		html: req.session.html,
   		css: req.session.css,
@@ -10,4 +10,4 @@ router.get('/', function(req, res, next) {
   	});
 });
 
-module.exports = router;
+export default router;

--- a/routes/bisect/view.js
+++ b/routes/bisect/view.js
@@ -1,10 +1,9 @@
-const express = require('express');
-const { replaceURLs } = require('./../../lib/functions.js');
-const { getSettings } = require('./../../lib/arguments.js');
+import express from 'express';
+import { replaceURLs } from './../../lib/functions.js';
+import args from './../../lib/arguments.js';
 
 const router = express.Router();
-
-
+const { getSettings } = args;
 
 const replaceHTML = (req) => {
 
@@ -36,4 +35,4 @@ router.get('/', function(req, res) {
   	});
 });
 
-module.exports = router;
+export default router;

--- a/routes/code.js
+++ b/routes/code.js
@@ -1,7 +1,9 @@
-const express = require('express');
-const router = express.Router();
-const { extname } = require('path');
-const { getCodeFile } = require('../lib/functions');
+import express from 'express';
+
+import { extname } from 'node:path';
+import { getCodeFile } from '../lib/functions.js';
+
+export const router = express.Router();
 
 router.get(/[a-z\/\-\.]/, async function(req, res) {
     let { content, error, path } = await getCodeFile(req.path, req);
@@ -33,4 +35,4 @@ router.get(/[a-z\/\-\.]/, async function(req, res) {
     }
 });
 
-module.exports = router;
+export default router;

--- a/routes/draft.js
+++ b/routes/draft.js
@@ -1,13 +1,14 @@
-const express = require('express');
+import express from 'express';
+import * as fs from 'node:fs';
+import { join } from 'node:path';
+
 const router = express.Router();
-const fs = require('fs');
-const { join } = require('path');
 
 router.get('/', function(req, res) {
 
-	let path = fs.readFileSync(join(__dirname, '../path.txt'), 'utf-8');
+	let path = fs.readFileSync(join(import.meta.dirname, '../path.txt'), 'utf-8');
 
 	res.redirect(`/samples/view?path=${path}&mobile=true`);
 });
 
-module.exports = router;
+export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,5 +1,6 @@
-const express = require('express');
-const path = require('path');
+import express from 'express';
+import * as path from 'path';
+
 const router = express.Router();
 
 /* GET home page. */
@@ -7,4 +8,4 @@ router.get('/', function(req, res, next) {
   	res.sendFile(path.join(__dirname + '/../views/index.html'));
 });
 
-module.exports = router;
+export default router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,8 +4,8 @@ import * as path from 'path';
 const router = express.Router();
 
 /* GET home page. */
-router.get('/', function(req, res, next) {
-  	res.sendFile(path.join(__dirname + '/../views/index.html'));
+router.get('/', function(req, res) {
+  	res.sendFile(path.join(import.meta.dirname, '/../views/index.html'));
 });
 
 export default router;

--- a/routes/pulls.js
+++ b/routes/pulls.js
@@ -1,8 +1,7 @@
-const express = require('express');
+import express from 'express';
+import { Octokit } from '@octokit/rest';
+
 const router = express.Router();
-
-const { Octokit } = require('@octokit/rest');
-
 const octokit = new Octokit({
     // https://github.com/settings/tokens
     auth: process.env.GH_PERSONAL_ACCESS_TOKEN
@@ -167,7 +166,7 @@ router.get('/list-checks/:ref', async (req, res) => {
 });
 
 
-module.exports = router;
+export default router;
 
 
 

--- a/routes/samples/compare-comment.js
+++ b/routes/samples/compare-comment.js
@@ -1,11 +1,12 @@
-const express = require('express');
-const fs = require('fs');
+import express from 'express';
+import * as fs from 'node:fs';
+import f from '../../lib/functions.js';
+import * as path from 'node:path';
+
 const router = express.Router();
-const f = require('../../lib/functions.js');
-const path = require('path');
 
 const getSavedCompare = (req) => {
-	let fileName = path.join(__dirname, '../../temp/compare.' +
+	let fileName = path.join(import.meta.dirname, '../../temp/compare.' +
 			f.getBranch() + '.' + req.query.browser + '.json');
 	let compare;
 	
@@ -44,4 +45,4 @@ router.get('/', function(req, res) {
 	});
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/compare-iframe.js
+++ b/routes/samples/compare-iframe.js
@@ -52,7 +52,7 @@ const getTemplates = () => {
 	).map(filename => '/' + filename.split('/public/')[1]);
 }
 
-router.get('/', function(req, res) {
+router.get('/', async function(req, res) {
 
 	const { compileOnDemand, emulateKarma } = getSettings(req);
 	let path = req.query.path;
@@ -70,7 +70,7 @@ router.get('/', function(req, res) {
 	let tpl = {
 		title: req.query.path,
 		html: emulateKarma ?
-			f.getKarmaHTML() :
+			await f.getKarmaHTML() :
 			getHTML(req, codePath),
 		css: f.getCSS(path, codePath),
 		js: getJS(path, req, codePath),

--- a/routes/samples/compare-iframe.js
+++ b/routes/samples/compare-iframe.js
@@ -2,12 +2,14 @@
  * Runs in an iframe, comparing candidate and reference.
  */
 
-const express = require('express');
-const f = require('./../../lib/functions.js');
-const glob = require('glob');
-const path = require('path');
+import express from 'express';
+import f from './../../lib/functions.js';
+import glob from 'glob';
+import * as path from 'node:path';
+import args from '../../lib/arguments.js';
+
 const router = express.Router();
-const { getSettings } = require('../../lib/arguments.js');
+const { getSettings } = args;
 
 const getHTML = (req, codePath) => {
 	let html = f.getHTML(req, codePath);
@@ -45,7 +47,7 @@ const getJS = (path, req, codePath) => {
 const getTemplates = () => {
 	return glob.sync(
 		path.join(
-			__dirname,
+			import.meta.dirname,
 			'../..',
 			'public/javascripts/test-templates/**/*.js'
 		)
@@ -93,4 +95,4 @@ router.get('/', async function(req, res) {
 	res.render('samples/compare-iframe', tpl);
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/compare-report.js
+++ b/routes/samples/compare-report.js
@@ -1,15 +1,15 @@
-const express = require('express');
-const {
+import express from 'express';
+import {
 	getBranch,
 	// getNightlyResult
-} = require('../../lib/functions.js');
-const fs = require('fs');
-const path = require('path');
+} from '../../lib/functions.js';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import ip from 'ip';
+
 const router = express.Router();
-const ip = require('ip');
 
 const browsers = ['Nightly', 'Chrome', 'Safari', 'Firefox', 'Edge', 'MSIE'];
-
 
 router.get('/', async (req, res) => {
 	let compare = {};
@@ -18,7 +18,7 @@ router.get('/', async (req, res) => {
 
 	browsers.forEach(browser => {
 		const file = path.join(
-			__dirname,
+			import.meta.dirname,
 			'../..',
 			'temp',
 			'compare.' + getBranch() + '.' + browser.toLowerCase() + '.json'
@@ -91,4 +91,4 @@ router.get('/', async (req, res) => {
 	});
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/compare-reset.js
+++ b/routes/samples/compare-reset.js
@@ -1,12 +1,13 @@
-const express = require('express');
+import express from 'express';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import glob from 'glob';
+
 const router = express.Router();
-const fs = require('fs');
-const path = require('path');
-const glob = require('glob');
 
 router.get('/', function(req, res) {
 	glob(path.join(
-		__dirname,
+		import.meta.dirname,
 		'../../temp/*.json'
 	), null, (err, files) => {
 
@@ -20,4 +21,4 @@ router.get('/', function(req, res) {
 	})
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/compare-update-report.js
+++ b/routes/samples/compare-update-report.js
@@ -1,13 +1,14 @@
-const express = require('express');
-const path = require('path');
+import express from 'express';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import f from '../../lib/functions.js';
+
 const router = express.Router();
-const fs = require('fs');
-const f = require('../../lib/functions.js');
 
 router.get('/', function(req, res) {
 	try {
 		let fileName = path.join(
-			__dirname,
+			import.meta.dirname,
 			'../../temp/compare.' +	f.getBranch().replace('/', '-') + '.' +
 			req.query.browser + '.json'
 		);
@@ -38,4 +39,4 @@ router.get('/', function(req, res) {
 	}
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/compare-view.js
+++ b/routes/samples/compare-view.js
@@ -1,5 +1,6 @@
-const express = require('express');
-const f = require('./../../lib/functions.js');
+import express from 'express';
+import f from './../../lib/functions.js';
+
 const router = express.Router();
 
 router.get('/', async function(req, res) {
@@ -23,4 +24,4 @@ router.get('/', async function(req, res) {
 	});
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/contents.js
+++ b/routes/samples/contents.js
@@ -1,4 +1,5 @@
-const express = require('express');
+import express from 'express';
+
 const router = express.Router();
 
 router.get('/', function(req, res) {
@@ -12,4 +13,4 @@ router.get('/', function(req, res) {
 	});
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/data.js
+++ b/routes/samples/data.js
@@ -1,15 +1,16 @@
-const express = require('express');
+import express from 'express';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import args from '../../lib/arguments.js';
+
 const router = express.Router();
-const fs = require('fs');
-const path = require('path');
-const { samplesDir } = require('../../lib/arguments.js');
-const { join } = require('path');
+const { samplesDir } = args;
 
 router.get(/[a-z\/\-\.0-9]+\.([a-z]+)$/, function(req, res) {
 
     const extname = path.extname(req.path).replace(/^./, '');
 
-    let file = join(samplesDir, 'data', req.path);
+    let file = path.join(samplesDir, 'data', req.path);
 
     if (!['gpx', 'mjs', 'js', 'json', 'csv', 'ttf', 'xml'].includes(extname)) {
         res.status(403).send(`
@@ -39,4 +40,4 @@ router.get(/[a-z\/\-\.0-9]+\.([a-z]+)$/, function(req, res) {
     res.sendFile(file);
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/index.js
+++ b/routes/samples/index.js
@@ -1,5 +1,6 @@
-const express = require('express');
-const path = require('path');
+import express from 'express';
+import * as path from 'node:path';
+
 const router = express.Router();
 
 /* GET samples home page. */
@@ -7,4 +8,4 @@ router.get('/', function(req, res, next) {
   	res.sendFile(path.join(__dirname + '/../../views/samples/index.html'));
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/index.js
+++ b/routes/samples/index.js
@@ -4,8 +4,8 @@ import * as path from 'node:path';
 const router = express.Router();
 
 /* GET samples home page. */
-router.get('/', function(req, res, next) {
-  	res.sendFile(path.join(__dirname + '/../../views/samples/index.html'));
+router.get('/', function(req, res) {
+  	res.sendFile(path.join(import.meta.dirname, '/../../views/samples/index.html'));
 });
 
 export default router;

--- a/routes/samples/list-samples.js
+++ b/routes/samples/list-samples.js
@@ -1,10 +1,11 @@
+import express from 'express';
+import f from './../../lib/functions.js';
+import * as fs from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import args from '../../lib/arguments.js';
 
-const express = require('express');
 const router = express.Router();
-const f = require('./../../lib/functions.js');
-const fs = require('fs');
-const { join, relative, sep } = require('path');
-const { samplesDir } = require('../../lib/arguments.js');
+const { samplesDir } = args;
 
 /**
  * Creates a serializable representation of a sample.
@@ -68,4 +69,4 @@ router.get('/', function(req, res) {
   	res.send(getSamples());
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/mobile.js
+++ b/routes/samples/mobile.js
@@ -1,6 +1,7 @@
-const express = require('express');
+import express from 'express';
+import ip from 'ip';
+
 const router = express.Router();
-const ip = require('ip');
 
 router.get('/', function(req, res) {
 	res.render('samples/mobile', {
@@ -13,4 +14,4 @@ router.get('/', function(req, res) {
 	});
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/nightly.js
+++ b/routes/samples/nightly.js
@@ -1,9 +1,9 @@
-const express = require('express');
-const {
+import express from 'express';
+import {
     getLatestTag,
     getNightlyResult
-} = require('../../lib/functions');
-const moment = require('moment'); // Using dateFormat
+} from '../../lib/functions.js';
+import moment from 'moment'; // Using dateFormat
 
 const router = express.Router();
 
@@ -138,4 +138,4 @@ router.get('/latest.json', async (req, res, next) => {
 
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/readme.js
+++ b/routes/samples/readme.js
@@ -1,19 +1,20 @@
-const express = require('express');
-const fs = require('fs');
-const marked = require('marked');
+import express from 'express';
+import * as fs from 'node:fs';
+import ip from 'ip';
+import * as marked from 'marked';
+import * as path from 'node:path';
+
 const router = express.Router();
-const path = require('path');
-const ip = require('ip');
 
 
 router.get('/', function(req, res) {
 	res.render('samples/readme', {
 		readme: marked.parse(
-			fs.readFileSync(path.join(__dirname, '../../lib/readme.md'))
+			fs.readFileSync(path.join(import.meta.dirname, '../../lib/readme.md'))
 				.toString()
 		),
 		ipAddress: ip.address()
 	});
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/server-env.js
+++ b/routes/samples/server-env.js
@@ -1,13 +1,14 @@
-const express = require('express');
+import express from 'express';
+import f from './../../lib/functions.js';
+
 const router = express.Router();
-const f = require('./../../lib/functions.js');
 
-router.get('/', function(req, res, next) {
+router.get('/', function(req, res) {
 
-	res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Type', 'application/json');
     res.send({
     	branch: f.getBranch()
     });
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/settings-post.js
+++ b/routes/samples/settings-post.js
@@ -1,12 +1,12 @@
-const express = require('express');
-const fs = require('fs').promises;
-const { join } = require('path');
+const express = await import('express');
+const fs = await import('fs').promises;
+const { join } = await import('path');
 const router = express.Router();
-const config = require('../../config.json');
+const config = await import('../../config.json');
 
 router.post('/', async (req, res) => {
 	const configUserPath = join(__dirname, '../../temp', 'config-user.json'),
-		configUser = require(configUserPath);
+		configUser = await import(configUserPath, { with: { type: "json" } });
 
 	// Quick settings
 	const onlyInBody = !!req.body['quickSettings'];

--- a/routes/samples/settings-post.js
+++ b/routes/samples/settings-post.js
@@ -1,11 +1,12 @@
-const express = await import('express');
-const fs = await import('fs').promises;
-const { join } = await import('path');
+import express from 'express';
+import * as fs from 'node:fs/promises';
+import { join } from 'node:path';
+import config from '../../config.json' with { type: 'json' };
+
 const router = express.Router();
-const config = await import('../../config.json');
 
 router.post('/', async (req, res) => {
-	const configUserPath = join(__dirname, '../../temp', 'config-user.json'),
+	const configUserPath = join(import.meta.dirname, '../../temp', 'config-user.json'),
 		configUser = await import(configUserPath, { with: { type: "json" } });
 
 	// Quick settings
@@ -43,4 +44,4 @@ router.post('/', async (req, res) => {
 	res.redirect(req.header('Referer'));
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/settings.js
+++ b/routes/samples/settings.js
@@ -1,7 +1,7 @@
-const express = require('express');
-const router = express.Router();
+import express from 'express';
+import { getConfig } from '../../lib/functions.js';
 
-const { getConfig } = require('../../lib/functions.js');
+const router = express.Router();
 
 router.get('/', async (req, res) => {
     const options = await getConfig();
@@ -12,4 +12,4 @@ router.get('/', async (req, res) => {
     });
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/share.js
+++ b/routes/samples/share.js
@@ -2,13 +2,15 @@
  * Share a sample
  */
 
-const express = require('express');
+import express from 'express';
+import f from '../../lib/functions.js';
+import fs from 'node:fs/promises';
+import ip from 'ip';
+import { join } from 'node:path';
+import args from '../../lib/arguments.js';
+
 const router = express.Router();
-const f = require('../../lib/functions.js');
-const fs = require('fs').promises;
-const ip = require('ip');
-const { join } = require('path');
-const { highchartsDir } = require('../../lib/arguments.js');
+const { highchartsDir } = args;
 
 router.get('/', async (req, res) => {
 
@@ -58,4 +60,4 @@ router.get('/', async (req, res) => {
     });
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/view-source.js
+++ b/routes/samples/view-source.js
@@ -1,8 +1,10 @@
-const express = require('express');
-const fs = require('fs');
+import express from 'express';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import args from '../../lib/arguments.js';
+
 const router = express.Router();
-const path = require('path');
-const { samplesDir } = require('../../lib/arguments.js');
+const { samplesDir } = args;
 
 router.get('/', function(req, res) {
   const htmlPath = path.join(
@@ -48,4 +50,4 @@ router.get('/', function(req, res) {
   });
 });
 
-module.exports = router;
+export default router;

--- a/routes/samples/view.js
+++ b/routes/samples/view.js
@@ -5,12 +5,13 @@
  * - Styled mode
  */
 
-const express = require('express');
+import express from 'express';
+import f from './../../lib/functions.js';
+import * as fs from 'node:fs';
+import ip from 'ip';
+import { join } from 'node:path';
+
 const router = express.Router();
-const f = require('./../../lib/functions.js');
-const fs = require('fs');
-const ip = require('ip');
-const { join } = require('path');
 
 router.get('/', async (req, res) => {
     let resources = f.getResources(req.query.path);
@@ -18,7 +19,7 @@ router.get('/', async (req, res) => {
     let codePath = req.query.rightcommit ?
         'https://github.highcharts.com/' + req.query.rightcommit :
         '/code';
-    fs.writeFile(join(__dirname, '../../path.txt'), req.query.path, 'utf-8', (err) => {
+    fs.writeFile(join(import.meta.dirname, '../../path.txt'), req.query.path, 'utf-8', (err) => {
         if (err) {
             console.log(err);
         }
@@ -69,4 +70,4 @@ router.get('/', async (req, res) => {
     res.render('samples/view', tpl);
 });
 
-module.exports = router;
+export default router;

--- a/utils/demo-data/world-population.js
+++ b/utils/demo-data/world-population.js
@@ -12,7 +12,7 @@ const Path = require('path');
 const Request = require('request');
 const { samplesDir } = require('../../lib/arguments.js');
 
-const countries = require(Path.join(__dirname, 'countries.json'));
+const countries = require(Path.join(import.meta.dirname, 'countries.json'));
 const csvParser = new RegExp('(?:^|\\s+|\\,)(?:\\"([^\\"]*?)\\")+', 'gm');
 const landUrl = 'http://api.worldbank.org/v2/en/indicator/AG.LND.TOTL.K2?downloadformat=csv';
 const populationUrl = 'http://api.worldbank.org/v2/en/indicator/SP.POP.TOTL?downloadformat=csv';


### PR DESCRIPTION
All route targets need to be upgraded to ESM.

To-do:
- [x] Configure package as ESM
- [x] Replace require with import
- [x] Replace module.exports with export default
- [ ] Fix git branch json
- [ ] Fix eslint parser