### PR TITLE
Added workaround for Connectors, to load file from CDN.

### DIFF
--- a/routes/samples/share.js
+++ b/routes/samples/share.js
@@ -27,6 +27,10 @@ router.get('/', async (req, res) => {
         .replace(
             `https://github.highcharts.com/${latestCommit}/mapdata/`,
             'https://code.highcharts.com/mapdata/'
+        )
+        .replace(
+            `https://github.highcharts.com/${latestCommit}/connectors/`,
+            'https://code.highcharts.com/connectors/'
         );
     const js = await fs.readFile(
         join(highchartsDir, 'samples', req.query.path, 'demo.js')


### PR DESCRIPTION
Needs a manual test if works fine, for example: https://highcharts.github.io/highcharts-utils/samples/#gh/7cac7bf0c7/sample/highcharts/demo/annotates-tsla-stock-price should render a chart