### PR TITLE
bugfix/101-compile-on-demand

### DIFF
--- a/lib/compile-on-demand.js
+++ b/lib/compile-on-demand.js
@@ -100,7 +100,7 @@ const replace = (js, umdConfig) => {
         // bundles and are not needed in secondary bundles
         // 'Core/Axis/AxisDefaults.ts': '',
         'Core/Chart/ChartDefaults.ts': '',
-        'Core/Color/Palettes.ts': '',
+        // 'Core/Color/Palettes.ts': '', // Breaks modules/indicators-all.js
         'Core/Foundation.ts': '',
         'Core/Renderer/SVG/SVGLabel.ts': '',
         // 'Core/Renderer/SVG/Symbols.ts': '', // Breaks modules/stock.js


### PR DESCRIPTION
Closes #101.
Prevented Palettes replacemant because it breaks Stock module.
