### PR TITLE
bugfix/assert-close-or-equal

### DIFF
--- a/public/javascripts/compare-iframe.js
+++ b/public/javascripts/compare-iframe.js
@@ -59,7 +59,7 @@ function compareHTML() {
 		        error = 0.00001; // default error
 		    }
 
-		    var result = number === expected || (number < expected + error && number > expected - error) || false;
+		    var result = number === expected || (number <= expected + error && number >= expected - error) || false;
 
 		    this.push(result, number, expected, message);
 		};


### PR DESCRIPTION
Made assert.close check the same as the karma in the main repo, so also pass when the expected is off by the error.

Old:
https://github.com/highcharts/highcharts-utils/blob/ce6b1bec9c0faaca0339d25b8b97612278fb169b/public/javascripts/compare-iframe.js#L62

New is based on:
https://github.com/highcharts/highcharts/blob/bcddd25ed94b3fead8fba2cce4652443a92296d1/test/karma-setup.js#L313
```ts
        var result = number === expected || (number <= expected + error && number >= expected - error) || false;
```