### PR TITLE
Add Grid Pro as primary file

### DIFF
--- a/lib/compile-on-demand.js
+++ b/lib/compile-on-demand.js
@@ -215,6 +215,7 @@ export const compile = async (filename) => {
     const isPrimaryFile = [
         '/dashboards/datagrid.src.js',
         '/grid/grid-lite.src.js',
+        '/grid/grid-pro.src.js',
         '/dashboards/dashboards.src.js',
         '/highcharts.src.js',
         '/highcharts-autoload.src.js',


### PR DESCRIPTION
Grid Pro has been taken out of Dashboards, and exists alongside Grid Lite, but standalone.