### PR TITLE
Resolve grid es-modules

### DIFF
--- a/lib/compile-on-demand.js
+++ b/lib/compile-on-demand.js
@@ -186,6 +186,10 @@ export const getMasterPath = (filename) => {
                 ''
             )
             .replace(
+                '/masters/grid/es-modules',
+                ''
+            )
+            .replace(
                 '/masters/dashboards/datagrid',
                 '/masters-datagrid/datagrid'
             )


### PR DESCRIPTION
When Grid Pro is no longer inside Dashboard we need this to resolve the files inside grid/es-modules