### PR TITLE
enh/compile-on-demand-grid

### DIFF
--- a/lib/compile-on-demand.js
+++ b/lib/compile-on-demand.js
@@ -269,7 +269,7 @@ export const compile = async (filename) => {
         entryPoints: [masterPath],
         bundle: !umdConfig.isEsModules,
         write: false,
-        globalName: isPrimaryFile ? 'Highcharts' : 'HighchartsModule',
+        globalName: umdConfig.name + (isPrimaryFile ? '' : 'Module'),
         plugins,
         banner: {
             js: umdConfig.isEsModules ? '' : isPrimaryFile ?


### PR DESCRIPTION
Fix compile on demand for the grid without namespaces.