### PR TITLE
Removed StockTools iconsURL from global options.

### DIFF
--- a/public/javascripts/view.js
+++ b/public/javascripts/view.js
@@ -141,11 +141,6 @@ window.setUp = function () {
 				// Avoid versioning
 				// libURL: 'https://code.highcharts.com/lib'
 				libURL: '/code/lib'
-			},
-			stockTools: {
-				gui: {
-					iconsURL: '/code/gfx/stock-icons/'
-				}
 			}
 		});
 


### PR DESCRIPTION
Removed StockTools iconsURL from global options. This PR is related to https://github.com/highcharts/highcharts/pull/22784, once it's merged into Highcharts, this PR should be merged too so that the icons in utils are rendered from the JS file and not from the server.