### PR TITLE
Fixed #124, Core/Utilities.ts replacement for post-refactor modules

### DIFF
--- a/lib/compile-on-demand-core.js
+++ b/lib/compile-on-demand-core.js
@@ -232,6 +232,15 @@ export function getDefaultReplacements(umdConfig) {
         'Shared/TimeBase.ts': `var TimeBase_default = ${umdConfig.name}.Time;`,
     };
 
+    // Core/Utilities.ts exports (uniqueKey, error, etc.) are available on the
+    // global namespace from the primary bundle. For Dashboards modules (like
+    // layout.js), preserve the bundled object instead.
+    if (umdConfig.name !== 'Dashboards') {
+        replacements['Core/Utilities.ts'] = `var Utilities_default =
+            window.Highcharts || window.Dashboards || window.Grid;
+        `;
+    }
+
     return replacements;
 }
 
@@ -247,21 +256,6 @@ export function applyReplacements(jsInput, umdConfig, customReplacements = {}) {
         ...getDefaultReplacements(umdConfig),
         ...customReplacements
     };
-
-    // Legacy Utilities resolution
-    if (
-        // If the Core/Utilities.ts file is loaded in a Dashboards module (like
-        // layout.js), we need to preserve the included object.
-        umdConfig.name !== 'Dashboards' &&
-        // Only do this for commmits prior to
-        // https://github.com/highcharts/highcharts/pull/24015
-        // Utils issue #124
-        jsInput.indexOf('Shared/Utilities.ts') === -1
-    ) {
-        replacements['Core/Utilities.ts'] = `var Utilities_default =
-            window.Highcharts || window.Dashboards || window.Grid;
-        `;
-    }
 
     let result = jsInput;
     for (const [path, replacement] of Object.entries(replacements)) {

--- a/lib/compile-on-demand-core.test.js
+++ b/lib/compile-on-demand-core.test.js
@@ -272,6 +272,28 @@ describe('applyReplacements', () => {
         const result = applyReplacements(mockJs, umdConfig, customReplacements);
         assert.ok(result.includes('var CustomFile_default = MyCustom;'));
     });
+
+    test('should replace Core/Utilities.ts even when Shared/Utilities.ts is present (issue #124)', () => {
+        const mockJs = `
+            // ../highcharts/ts/Shared/Utilities.ts
+            var SharedUtils = { addEvent: function() {} };
+            // ../highcharts/ts/Core/Utilities.ts
+            var CoreUtils = { uniqueKey: function() {} };
+            // ../highcharts/ts/Core/Globals.ts
+        `;
+        const umdConfig = { name: 'Highcharts', isEsModules: false, shortPath: 'highcharts' };
+        const result = applyReplacements(mockJs, umdConfig);
+        // Core/Utilities.ts should be replaced with global lookup
+        assert.ok(
+            result.includes('window.Highcharts'),
+            'Core/Utilities.ts should be replaced even when Shared/Utilities.ts is present'
+        );
+        // The original CoreUtils content should be gone
+        assert.ok(
+            !result.includes('var CoreUtils = { uniqueKey'),
+            'Original Core/Utilities.ts content should be replaced'
+        );
+    });
 });
 
 describe('generatePrimaryUMDHeader', () => {


### PR DESCRIPTION
## Fix: `uniqueKey is not defined` in compile-on-demand

Fixes #124

### Problem
When compiling non-primary Highcharts modules (e.g. `data.src.js`) via esbuild compile-on-demand, `uniqueKey is not defined` errors occur at runtime. The `Shared/Utilities.ts` presence check in `applyReplacements` caused `Core/Utilities.ts` replacement to be skipped for post-refactor bundles.

### Fix
Moved `Core/Utilities.ts` replacement back into `getDefaultReplacements` (where it was before commit `13c49c97`), removing the conditional `Shared/Utilities.ts` check from `applyReplacements`. The replacement is still excluded for Dashboards modules.

### Changes
- `lib/compile-on-demand-core.js`: Moved `Core/Utilities.ts` replacement into `getDefaultReplacements` with `umdConfig.name !== 'Dashboards'` guard, removed conditional block from `applyReplacements`
- `lib/compile-on-demand-core.test.js`: Added regression test verifying `Core/Utilities.ts` is replaced even when `Shared/Utilities.ts` is present
