### PR TITLE
Third attempt at fixing named imports of Core/Utilities.js

### DIFF
--- a/lib/compile-on-demand-core.js
+++ b/lib/compile-on-demand-core.js
@@ -233,15 +233,6 @@ export function getDefaultReplacements(umdConfig) {
         'Shared/TimeBase.ts': `var TimeBase_default = ${umdConfig.name}.Time;`,
     };
 
-    // Core/Utilities.ts exports (uniqueKey, error, etc.) are available on the
-    // global namespace from the primary bundle. For Dashboards modules (like
-    // layout.js), preserve the bundled object instead.
-    if (umdConfig.name !== 'Dashboards') {
-        replacements['Core/Utilities.ts'] = `var Utilities_default =
-            window.Highcharts || window.Dashboards || window.Grid;
-        `;
-    }
-
     return replacements;
 }
 


### PR DESCRIPTION
We've made two attempts earlier:

* https://github.com/highcharts/highcharts-utils/pull/125/changes 
* https://github.com/highcharts/highcharts-utils/pull/127/changes

The new proposal is to remove the whole concept of loading these utiliity functions from the mothership. Esbuild inlines them, so as far as I can see it works without any hacks. 

If we wanted to load them from the primary bundle instead, like in the official bundles, we would have to do something like
```
    if (umdConfig.name !== 'Dashboards') {
        replacements['Core/Utilities.ts'] = `var { error, uniqueKey }  = ${umdConfig.name}`;
    }
```
It would be hard to maintain, so if we go this route in the future we need to do it smarter.